### PR TITLE
#63 Performance verbeteringen

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,8 +5,11 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	%sveltekit.head%
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/chartscss@1.0.0/dist/charts.min.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/charts.css/dist/charts.min.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/charts.css/dist/charts.min.css">
+	<link rel="preload" href="/global.css" as="style" onload="this.rel='stylesheet'">
+	<noscript>
+		<link rel="stylesheet" href="/global.css">
+	</noscript>
 </head>
 
 <body data-sveltekit-preload-data="hover">

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -10,7 +10,15 @@
 <aside class:open={sidebarOpen} id="sidebar">
   <!-- Sidebar header with logo -->
   <header class="sidebar-header">
-    <img src={logoSrc} alt="IWGDF Logo" class="logo-img" />
+    <img
+      src={logoSrc}
+      alt="IWGDF Logo"
+      width="120"
+      height="40"
+      decoding="async"
+      fetchpriority="high"
+      class="logo-img"
+    />
   </header>
 
   <!-- Navigation menu -->
@@ -42,9 +50,11 @@
     <span class="user-avatar">
       <img
         src="https://iwgdfguidelines.org/wp-content/uploads/2023/05/jvn-highres-square-scaled.jpg"
-        alt=""
+        alt="Profielfoto gebruiker"
         width="50"
         height="50"
+        loading="lazy"
+        decoding="async"
         class="avatar-img"
       />
     </span>
@@ -206,6 +216,7 @@
   /* Avatar image styling */
   .avatar-img {
     border-radius: 9999px;
+    background-color: var(--grey-100);
   }
 
   /* User info text container */

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -4,9 +4,12 @@
 }
 
 @font-face {
-    font-family: 'MontserratRegular';
-    src: url(/src/lib/assets/fonts/Montserrat-VariableFont_wght.ttf);
+    font-family: 'Montserrat';
+    src: url(/src/lib/assets/fonts/Montserrat-VariableFont_wght.ttf) format('truetype');
+    font-weight: 100 900;
+    font-display: swap;
 }
+
 
 html,
 body {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { onMount } from "svelte";
+
   import IWGDF from "$lib/assets/IWGDF-logo.png";
 
   // Components


### PR DESCRIPTION
Font-swap, import OnMount, lazy loading, preload etc.

## What does this change?

Resolves issue #63 

- Fonts krijgen font-display: swap zodat tekst sneller zichtbaar is.
- onMount zorgt dat zware code pas op de client draait, niet tijdens SSR.
- Grote componenten (bijv. charts) worden lazy geladen, dus pas als nodig.
- Kritieke assets worden gepreload, waardoor de pagina sneller laadt.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] Charts laden pas als de sidebar zichtbaar is
- [x]  Fonts renderen correct
- [x]  Lighthouse score mobiel verbeterd (56 → 75 → 100/99)
- [x]  Werkt op mobiel en desktop, verschillende browsers

## How to review

- Local lighthouse test
