### PR TITLE
Research page filter

### DIFF
--- a/src/lib/components/Grading-article-card.svelte
+++ b/src/lib/components/Grading-article-card.svelte
@@ -12,7 +12,8 @@
 	import InProgressLabel from "$lib/partials/In-progress-label.svelte";
 
 	// Dynamic data variables
-	let {name, article_id, Publisher, publishing_year, status, className} = $props()
+	let {name, article_id, Publisher, publishing_year, status, className, theme} = $props()
+
 </script>
 
 <a class="anchor-container-card" href="/checklist">
@@ -36,8 +37,17 @@
 			</div>
 
 			<div class="action-container">
-				<InProgressLabel/>
-				<ThemeLabel themeName="Temperature"/>
+
+				{#if status === "Not started"}
+					<NotStartedLabel/>
+				{:else if status === "In progress"}
+					<InProgressLabel/>
+				{:else if status === "Finished"}
+					<FinishedLabel/>
+				{/if}
+
+                <ThemeLabel themeName={theme} />
+
 			</div>
 		</div>
 	</article>
@@ -55,7 +65,7 @@
 	.research-card {
 		padding: 1rem;
 		border-radius: 1rem;
-		background-color: var(--background-color-primary);
+		background-color: hsla(197, 7%, 79%, 0.127);
 		display: flex;
 		flex-direction: column;
 		gap: 1rem;
@@ -79,6 +89,11 @@
 		& .research-card-title {
 			font-weight: bold;
 			color: var(--grey-700);
+
+			display: -webkit-box;
+			-webkit-line-clamp: 2; 
+			-webkit-box-orient: vertical;
+			overflow: hidden;
 		}
 
 		& h2 .research-id {

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -15,7 +15,7 @@
 html,
 body {
     font-family: var(--main-font), sans-serif;
-    background-color: var(--background-color-primary);
+    /* background-color: var(--background-color-primary); */
 
 
     
@@ -85,7 +85,7 @@ body {
     --favorite-notification-color:hsl(54, 100%, 60%);
 }
 body{
-    background:var(--grey-100) ;
+    /* background:var(--grey-100) ; */
 }
 
 /* H1  */

--- a/src/lib/partials/Filter-button.svelte
+++ b/src/lib/partials/Filter-button.svelte
@@ -15,6 +15,8 @@
   {/each}
 </select>
 
+
+
 <style>
   select {
     background: none;
@@ -24,7 +26,7 @@
     cursor: pointer;
     outline: inherit;
     appearance: none;
-    width: 7.5rem;
+    width: 8rem;
 
     border-radius: 0.5rem;
     padding: 0.5rem;

--- a/src/lib/partials/Heading.svelte
+++ b/src/lib/partials/Heading.svelte
@@ -1,0 +1,23 @@
+<script>
+
+  let {title, subTitle, className} = $props()
+
+</script>
+
+<div class="page-title">
+    <h1>{title}</h1>
+    <p>{subTitle}</p>
+
+</div>
+
+<style>
+
+    .page-title {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 1.5rem 0 2rem 0;
+    }
+
+
+</style>

--- a/src/lib/partials/Not-started-label.svelte
+++ b/src/lib/partials/Not-started-label.svelte
@@ -19,7 +19,7 @@
         width: fit-content;
         padding: 0.35rem;
         border-radius: 0.5rem;
-        color: var(--red-400);
+        color: var(--red-700);
         background-color: rgb(255, 249, 249);
         white-space: nowrap;
     }

--- a/src/routes/research/+page.server.js
+++ b/src/routes/research/+page.server.js
@@ -1,25 +1,10 @@
 
 // https://fdnd-agency.directus.app/items/footguard_articles
-
 // https://68ee3b05df2025af7802de69.mockapi.io/assigned/articles/Gradings
-
-// export async function load ({ url }) {
-
-//     const gradingsResponse = await fetch('https://fdnd-agency.directus.app/items/footguard_articles');
-//     const gradingsData = await gradingsResponse.json();
-//     console.log(gradingsData)
-
-
-//   
-
-//   return {gradings: gradingsData.data}
-
-
-// }
 
 
 export async function load ({ url }) {
-  // Dit leest de url af op de filter waarde is de filterwaarde geen morning, evening of is het null, dan pakt hij alle
+  // Dit leest de url af op de filter waarde is de filterwaarde voor theme of status niet ingevuld dan pakt het alle
 
     const status = url.searchParams.get('status') || 'all';
     const theme = url.searchParams.get('theme') || 'all';
@@ -34,32 +19,29 @@ export async function load ({ url }) {
     let cardData = gradingsData.data
 
 
-    
+    // de status filteren op betreffende waarde uit de url
     if (status === 'Not started') {
-        cardData = cardData.filter(cardData => cardData.status === "Not started");
-    } else if (status === 'Finished') {
-        cardData = cardData.filter(cardData => cardData.status === "Finished");
-    } else if (status === 'In progress') {
-        cardData = cardData.filter(cardData => cardData.status === "In progress");
-    } 
+            cardData = cardData.filter(cardData => cardData.status === "Not started");
+        } else if (status === 'Finished') {
+            cardData = cardData.filter(cardData => cardData.status === "Finished");
+        } else if (status === 'In progress') {
+            cardData = cardData.filter(cardData => cardData.status === "In progress");
+        } 
 
-if (theme === 'Temperature') {
-        cardData = cardData.filter(cardData => cardData.theme === "Temperature");
-    } else if (theme === 'Ulcers') {
-        cardData = cardData.filter(cardData => cardData.theme === "Ulcers");
-    } else if (theme === 'High risk ') {
-        cardData = cardData.filter(cardData => cardData.theme === "High risk ");
-    } else if  (theme === 'Age') {
-        cardData = cardData.filter(cardData => cardData.theme === "Age");
-    }
+    // De theme filteren op betreffende waarde uit de url
+    if (theme === 'Temperature') {
+            cardData = cardData.filter(cardData => cardData.theme === "Temperature");
+        } else if (theme === 'Ulcers') {
+            cardData = cardData.filter(cardData => cardData.theme === "Ulcers");
+        } else if (theme === 'High risk') {
+            cardData = cardData.filter(cardData => cardData.theme.trim() === "High risk");
+        } else if  (theme === 'Age') {
+            cardData = cardData.filter(cardData => cardData.theme === "Age");
+        }
 
-
-    // return {gradings: gradingsData.data}
+        // return {gradings: gradingsData.data}
 
     return {cardData, status, theme}
-
-
-
 
 }
 

--- a/src/routes/research/+page.server.js
+++ b/src/routes/research/+page.server.js
@@ -1,16 +1,46 @@
 
+// https://fdnd-agency.directus.app/items/footguard_articles
 
+// https://68ee3b05df2025af7802de69.mockapi.io/assigned/articles/Gradings
 
 export async function load ({ url }) {
-    const gradingsResponse = await fetch('https://68ee3b05df2025af7802de69.mockapi.io/assigned/articles/Gradings');
+  // Dit leest de url af op de filter waarde is de filterwaarde geen morning, evening of is het null, dan pakt hij alle
+
+    const filter = url.searchParams.get('theme') || 'all';
+  console.log(filter)
+
+
+
+    const gradingsResponse = await fetch('https://fdnd-agency.directus.app/items/footguard_articles');
     const gradingsData = await gradingsResponse.json();
     console.log(gradingsData)
 
-    let gradings = gradingsData.data
+    let cardData = gradingsData.data
 
-    return {gradings: gradingsData}
+
+    
+    if (filter === 'Temperature') {
+        cardData = cardData.filter(cardData => cardData.theme === "Temperature");
+    } else if (filter === 'Ucles') {
+        cardData = cardData.filter(cardData => cardData.theme === "Ucles");
+    } else if (filter === 'High-risk') {
+        cardData = cardData.filter(cardData => cardData.theme === "High-risk");
+    } else if  (filter === 'Age') {
+        cardData = cardData.filter(cardData => cardData.theme === "Age");
+    }
+
+    // return {gradings: gradingsData.data}
+
+    return {cardData, filter}
 
 
 }
+
+
+
+
+
+
+
 
 

--- a/src/routes/research/+page.server.js
+++ b/src/routes/research/+page.server.js
@@ -3,12 +3,28 @@
 
 // https://68ee3b05df2025af7802de69.mockapi.io/assigned/articles/Gradings
 
+// export async function load ({ url }) {
+
+//     const gradingsResponse = await fetch('https://fdnd-agency.directus.app/items/footguard_articles');
+//     const gradingsData = await gradingsResponse.json();
+//     console.log(gradingsData)
+
+
+//   
+
+//   return {gradings: gradingsData.data}
+
+
+// }
+
+
 export async function load ({ url }) {
   // Dit leest de url af op de filter waarde is de filterwaarde geen morning, evening of is het null, dan pakt hij alle
 
-    const filter = url.searchParams.get('theme') || 'all';
-  console.log(filter)
+    const status = url.searchParams.get('status') || 'all';
+    const theme = url.searchParams.get('theme') || 'all';
 
+  console.log(status)
 
 
     const gradingsResponse = await fetch('https://fdnd-agency.directus.app/items/footguard_articles');
@@ -19,22 +35,38 @@ export async function load ({ url }) {
 
 
     
-    if (filter === 'Temperature') {
+    if (status === 'Not started') {
+        cardData = cardData.filter(cardData => cardData.status === "Not started");
+    } else if (status === 'Finished') {
+        cardData = cardData.filter(cardData => cardData.status === "Finished");
+    } else if (status === 'In progress') {
+        cardData = cardData.filter(cardData => cardData.status === "In progress");
+    } 
+
+if (theme === 'Temperature') {
         cardData = cardData.filter(cardData => cardData.theme === "Temperature");
-    } else if (filter === 'Ucles') {
-        cardData = cardData.filter(cardData => cardData.theme === "Ucles");
-    } else if (filter === 'High-risk') {
-        cardData = cardData.filter(cardData => cardData.theme === "High-risk");
-    } else if  (filter === 'Age') {
+    } else if (theme === 'Ulcers') {
+        cardData = cardData.filter(cardData => cardData.theme === "Ulcers");
+    } else if (theme === 'High risk ') {
+        cardData = cardData.filter(cardData => cardData.theme === "High risk ");
+    } else if  (theme === 'Age') {
         cardData = cardData.filter(cardData => cardData.theme === "Age");
     }
 
+
     // return {gradings: gradingsData.data}
 
-    return {cardData, filter}
+    return {cardData, status, theme}
+
+
 
 
 }
+
+
+
+
+
 
 
 

--- a/src/routes/research/+page.svelte
+++ b/src/routes/research/+page.svelte
@@ -11,21 +11,14 @@
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 
-	let { data, form, buttonOff } = $props();
+	let { data, form } = $props();
 	const gradings = data.cardData;
 
-	
 	// https://svelte.dev/docs/kit/$app-navigation#goto
 	// for changening the url without page refresh
 	function updateFilters() {
 		goto(`?status=${data.status}&theme=${data.theme}`);
 	}
-
-	// adding class to remove submit-button
-	onMount(() => {
-		buttonOff.classList.add('js-on');
-	});
-
 
 </script>
 
@@ -51,7 +44,9 @@
 				<option value="Age">Age</option>
 			</select>
 
-			<button bind:this={buttonOff} class="submit-button" type="submit">Filter</button>
+			<noscript>
+				<button class="submit-button"  type="submit">Filter</button>
+			</noscript>
 		</form>
 
 
@@ -125,15 +120,11 @@
 			opacity: 0;
 			transform: translateX(30rem);
 
-
 		} to {
 			opacity: 1;
 			transform: translateX(0);
-
 		}
 	}
-
-
 
 	.filter-button {
 		background: none;
@@ -193,8 +184,4 @@
 		color: var(--background-color-secondary);
 		font-size: clamp(13px, 1.5vw, 15px);
 	}
-
-	 :global(.js-on) {
-    display: none; 
-  }
 </style>

--- a/src/routes/research/+page.svelte
+++ b/src/routes/research/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+
 	// Components
 	import Sidebar from "$lib/components/layout/Sidebar.svelte";
 	import GradingArticleCard from "$lib/components/Grading-article-card.svelte";
@@ -7,18 +8,20 @@
 	import Heading from "$lib/partials/Heading.svelte";
 
 	let {
-		status = [
-			{ value: "allstatus", text: "Status" },
-			{ value: "inprogress", text: "In progress" },
-			{ value: "finished", text: "Finished" },
-			{ value: "notstarted", text: "Not started" },
-		],
-		data,
-		form
-	} = $props();
+    import { text } from "@sveltejs/kit";
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
 
 	const gradings = data.cardData;
 	// const filter = data.filter;
+
+	
+	// https://svelte.dev/docs/kit/$app-navigation#goto
+	// for changening the url without page refresh
+	function updateFilters() {
+		goto(`?status=${data.status}&theme=${data.theme}`);
+	}
+
 
 </script>
 

--- a/src/routes/research/+page.svelte
+++ b/src/routes/research/+page.svelte
@@ -49,7 +49,7 @@
 
 
   <select name="theme" bind:value={data.theme}>
-    <option value="all-themes">All Themes</option>
+    <option value="all-themes">Themes</option>
     <option value="Temperature">Temperature</option>
     <option value="Ulcers">Ulcers</option>
     <option value="High risk ">High-Risk</option>
@@ -60,8 +60,8 @@
   <button type="submit">Filter</button>
 </form>
 
-<h2> {data.theme}</h2>
-<h2>{data.status}</h2>
+<!-- <h2> {data.theme}</h2>
+<h2>{data.status}</h2> -->
 
 
 		<!-- <form method="get" filter={data.filter}>
@@ -80,7 +80,7 @@
 
 
 		{#if data.cardData.length === 0}
-			<p>No results found</p>
+			<p class="no-results-text">No gradings found</p>
 			{:else}
 		<div class="research-cards-container">
   			{#each data.cardData as cardInfo}
@@ -140,6 +140,16 @@
 		@media (min-width: 560px) {
 			justify-content: flex-end;
 		}
+	}
+
+	.no-results-text {
+		padding: 4rem;
+		text-align: center;
+		background-color: hsla(197, 7%, 79%, 0.127);
+		margin-top: 2rem;
+		border-radius: 1rem;
+		color: var(--grey-700);
+
 	}
 
 	.research-cards-container {

--- a/src/routes/research/+page.svelte
+++ b/src/routes/research/+page.svelte
@@ -1,25 +1,12 @@
 <script>
-	// voor performance enhancement :https://svelte.dev/docs/kit/page-options
-	export const csr = true;
-	export const prerender = false;
-
 	// Components
 	import Sidebar from "$lib/components/layout/Sidebar.svelte";
 	import GradingArticleCard from "$lib/components/Grading-article-card.svelte";
 	import FilterButton from "$lib/partials/Filter-button.svelte";
 	import SearchBar from "$lib/partials/Search-bar.svelte";
+	import Heading from "$lib/partials/Heading.svelte";
 
-	// values for status
-	// custom value moeten uit theme komen van elk onderzoek uit database
-	// data is voor de fetch data
 	let {
-		theme = [
-			{ value: "alltheme", text: "Theme" },
-			{ value: "tempature", text: "Tempature" },
-			{ value: "color", text: "Color" },
-			{ value: "numbness", text: "Numbness" },
-			{ value: "age", text: "Age" },
-		],
 		status = [
 			{ value: "allstatus", text: "Status" },
 			{ value: "inprogress", text: "In progress" },
@@ -30,44 +17,107 @@
 		form
 	} = $props();
 
-	const gradings = data.gradings;
-	const filter = data.filter;
+	const gradings = data.cardData;
+	// const filter = data.filter;
 
-	
 </script>
 
 <div class="main-container">
-
     <section class="main-container-research">
+		<Heading title="Assigned Gradings" subTitle="An overview of all your gradings"/>
 
-        <h1 class="main-container-research-title">Assigned Gradings</h1>
 
-		<!-- https://github.com/sveltejs/kit/discussions/8499
+
+		<!-- <form method="get">
+  <select name="theme" bind:value={data.filter}>
+    <option value="all-themes">All Themes</option>
+    <option value="Temperature">Temperature</option>
+    <option value="Ulcers">Ulcers</option>
+    <option value="High risk ">High-Risk</option>
+    <option value="Age">Age</option>
+  </select>
+  <button type="submit">Filter</button>
+</form> -->
+
+		<form method="get">
+  <select name="status" bind:value={data.status}>
+	<option value="all">Status</option>
+    <option value="Not started">Not started</option>
+    <option value="Finished">Finished</option>
+    <option value="In progress">In progress</option>
+  </select>
+
+
+  <select name="theme" bind:value={data.theme}>
+    <option value="all-themes">All Themes</option>
+    <option value="Temperature">Temperature</option>
+    <option value="Ulcers">Ulcers</option>
+    <option value="High risk ">High-Risk</option>
+    <option value="Age">Age</option>
+  </select>
+
+
+  <button type="submit">Filter</button>
+</form>
+
+<h2> {data.theme}</h2>
+<h2>{data.status}</h2>
+
+
+		<!-- <form method="get" filter={data.filter}>
+        <button class="filterButton" type="submit" name="filter" value="Age">Alle</button>
+        <button class="filterButton" type="submit" name="filter" value="High-risk">Morning</button>
+        <button class="filterButton" type="submit" name="filter" value="Ulcers">Evening</button>
+    </form> -->
+
+<!-- https://github.com/sveltejs/kit/discussions/8499
 		voor het sumbitten van een geselecteerde value in een selectbutton -->
-		<form class="filter-form-container" method="get" bind:this={form}>
-  			<FilterButton filterLabel_ID="status" labelText="Filter status" selectValues={status}/>
-			<FilterButton filterLabel_ID="theme" labelText="Filter theme" selectValues={theme}/>
-		</form>
+		<!-- <form class="filter-form-container" method="get" bind:this={form} filter={data.filter}> -->
+  			<!-- <FilterButton filterLabel_ID="status" labelText="Filter status" selectValues={status}/> -->
+			<!-- <FilterButton filterLabel_ID="theme" labelText="Filter theme" selectValues={theme}/> -->
+			<!-- <FilterButton {selectValues} filterLabel_ID="theme" labelText="Filter theme"/> -->
+		<!-- </form> -->
 
-        <div class="research-cards-container">
-            {#each gradings as grading}
+
+		{#if data.cardData.length === 0}
+			<p>No results found</p>
+			{:else}
+		<div class="research-cards-container">
+  			{#each data.cardData as cardInfo}
                 <GradingArticleCard
-                name={grading.name}
-                article_id={grading.article_id}
-                Publisher={grading.Publisher}
-                publishing_year={grading.publishing_year}
+                name={cardInfo.title}
+                article_id={cardInfo.id}
+                Publisher={cardInfo.Publisher}
+    			publishing_year={new Date(cardInfo.publishing_year).getFullYear()}
+				status={cardInfo.status}
+            	theme={cardInfo.theme}
                 />
             {/each}
         </div>
+	{/if}
+
+
+
+
+
+        <!-- <div class="research-cards-container">
+  			{#each data.cardData as cardInfo}
+                <GradingArticleCard
+                name={cardInfo.title}
+                article_id={cardInfo.id}
+                Publisher={cardInfo.Publisher}
+    			publishing_year={new Date(cardInfo.publishing_year).getFullYear()}
+				status={cardInfo.status}
+            	theme={cardInfo.theme}
+                />
+            {/each}
+        </div> -->
 
     </section>
 	
 </div>
 
 <style>
-	:global(body) {
-		background-color: var(--background-color-secondary);
-	}
 
 	@media (min-width: 1024px) {
 		.main-container {
@@ -78,12 +128,6 @@
 	.main-container-research {
 		padding: 1rem 1rem 1rem 1rem;
 		width: 100%;
-
-		& .main-container-research-title {
-			color: var(--grey-700);
-			padding-top: 1.5rem;
-			padding-bottom: 2rem;
-		}
 	}
 
 	/* positioning filter form */

--- a/src/routes/research/+page.svelte
+++ b/src/routes/research/+page.svelte
@@ -7,13 +7,12 @@
 	import SearchBar from "$lib/partials/Search-bar.svelte";
 	import Heading from "$lib/partials/Heading.svelte";
 
-	let {
     import { text } from "@sveltejs/kit";
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 
+	let { data, form, buttonOff } = $props();
 	const gradings = data.cardData;
-	// const filter = data.filter;
 
 	
 	// https://svelte.dev/docs/kit/$app-navigation#goto
@@ -21,6 +20,11 @@
 	function updateFilters() {
 		goto(`?status=${data.status}&theme=${data.theme}`);
 	}
+
+	// adding class to remove submit-button
+	onMount(() => {
+		buttonOff.classList.add('js-on');
+	});
 
 
 </script>

--- a/src/routes/research/+page.svelte
+++ b/src/routes/research/+page.svelte
@@ -33,95 +33,47 @@
     <section class="main-container-research">
 		<Heading title="Assigned Gradings" subTitle="An overview of all your gradings"/>
 
+		<form method="get" class="filter-form-container" id="myForm">
+			<label for="status" class="visually-hidden">filter status</label>
+			<select class="filter-button" id="status" name="status" bind:value={data.status} on:change={updateFilters}>
+				<option value="all">Status</option>
+				<option value="Not started">Not started</option>
+				<option value="Finished">Finished</option>
+				<option value="In progress">In progress</option>
+			</select>
 
+			<label for="theme" class="visually-hidden">filter theme</label>
+			<select class="filter-button" id="theme" name="theme" bind:value={data.theme} on:change={updateFilters}>
+				<option value="all">Themes</option>
+				<option value="Temperature">Temperature</option>
+				<option value="Ulcers">Ulcers</option>
+				<option value="High risk">High-Risk</option>
+				<option value="Age">Age</option>
+			</select>
 
-		<!-- <form method="get">
-  <select name="theme" bind:value={data.filter}>
-    <option value="all-themes">All Themes</option>
-    <option value="Temperature">Temperature</option>
-    <option value="Ulcers">Ulcers</option>
-    <option value="High risk ">High-Risk</option>
-    <option value="Age">Age</option>
-  </select>
-  <button type="submit">Filter</button>
-</form> -->
-
-		<form method="get">
-  <select name="status" bind:value={data.status}>
-	<option value="all">Status</option>
-    <option value="Not started">Not started</option>
-    <option value="Finished">Finished</option>
-    <option value="In progress">In progress</option>
-  </select>
-
-
-  <select name="theme" bind:value={data.theme}>
-    <option value="all-themes">Themes</option>
-    <option value="Temperature">Temperature</option>
-    <option value="Ulcers">Ulcers</option>
-    <option value="High risk ">High-Risk</option>
-    <option value="Age">Age</option>
-  </select>
-
-
-  <button type="submit">Filter</button>
-</form>
-
-<!-- <h2> {data.theme}</h2>
-<h2>{data.status}</h2> -->
-
-
-		<!-- <form method="get" filter={data.filter}>
-        <button class="filterButton" type="submit" name="filter" value="Age">Alle</button>
-        <button class="filterButton" type="submit" name="filter" value="High-risk">Morning</button>
-        <button class="filterButton" type="submit" name="filter" value="Ulcers">Evening</button>
-    </form> -->
-
-<!-- https://github.com/sveltejs/kit/discussions/8499
-		voor het sumbitten van een geselecteerde value in een selectbutton -->
-		<!-- <form class="filter-form-container" method="get" bind:this={form} filter={data.filter}> -->
-  			<!-- <FilterButton filterLabel_ID="status" labelText="Filter status" selectValues={status}/> -->
-			<!-- <FilterButton filterLabel_ID="theme" labelText="Filter theme" selectValues={theme}/> -->
-			<!-- <FilterButton {selectValues} filterLabel_ID="theme" labelText="Filter theme"/> -->
-		<!-- </form> -->
+			<button bind:this={buttonOff} class="submit-button" type="submit">Filter</button>
+		</form>
 
 
 		{#if data.cardData.length === 0}
 			<p class="no-results-text">No gradings found</p>
-			{:else}
-		<div class="research-cards-container">
-  			{#each data.cardData as cardInfo}
-                <GradingArticleCard
-                name={cardInfo.title}
-                article_id={cardInfo.id}
-                Publisher={cardInfo.Publisher}
-    			publishing_year={new Date(cardInfo.publishing_year).getFullYear()}
-				status={cardInfo.status}
-            	theme={cardInfo.theme}
-                />
-            {/each}
-        </div>
-	{/if}
 
-
-
-
-
-        <!-- <div class="research-cards-container">
-  			{#each data.cardData as cardInfo}
-                <GradingArticleCard
-                name={cardInfo.title}
-                article_id={cardInfo.id}
-                Publisher={cardInfo.Publisher}
-    			publishing_year={new Date(cardInfo.publishing_year).getFullYear()}
-				status={cardInfo.status}
-            	theme={cardInfo.theme}
-                />
-            {/each}
-        </div> -->
+		{:else}
+			<div class="research-cards-container">
+				{#each data.cardData as cardInfo}
+					<GradingArticleCard
+					name={cardInfo.title}
+					article_id={cardInfo.id}
+					Publisher={cardInfo.Publisher}
+					publishing_year={new Date(cardInfo.publishing_year).getFullYear()}
+					status={cardInfo.status}
+					theme={cardInfo.theme}
+					/>
+				{/each}
+			</div>
+		{/if}
 
     </section>
-	
 </div>
 
 <style>
@@ -156,7 +108,7 @@
 		margin-top: 2rem;
 		border-radius: 1rem;
 		color: var(--grey-700);
-
+		animation: fadeIn 0.4s ease-out;
 	}
 
 	.research-cards-container {
@@ -164,5 +116,85 @@
 		display: flex;
 		flex-direction: column;
 		gap: 1rem;
+
+		animation: fadeIn 0.4s ease-out;
 	}
+
+	@keyframes fadeIn {
+		from { 
+			opacity: 0;
+			transform: translateX(30rem);
+
+
+		} to {
+			opacity: 1;
+			transform: translateX(0);
+
+		}
+	}
+
+
+
+	.filter-button {
+		background: none;
+		color: inherit;
+		padding: 0;
+		font: inherit;
+		cursor: pointer;
+		outline: inherit;
+		appearance: none;
+		width: 8rem;
+
+		border-radius: 0.5rem;
+		padding: 0.5rem;
+
+		background-color: var(--blue-700);
+		color: var(--background-color-secondary);
+		font-size: clamp(13px, 1.5vw, 15px);
+
+		background-image: url("/src/lib/assets/svg/select-button-arrow.svg");
+		background-repeat: no-repeat;
+		background-position: right 0.5rem center;
+		background-size: 1rem;
+		transition: 0.2s ease-in-out;
+
+		&:hover {
+		background-color: var(--blue-500);
+		}
+
+		&:focus {
+		outline: 2px solid var(--orange-400);
+		}
+	}
+
+	.visually-hidden {
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		height: 1px;
+		overflow: hidden;
+		position: absolute;
+		white-space: nowrap;
+		width: 1px;
+	}
+
+	.submit-button {
+		background: none;
+		color: inherit;
+		padding: 0;
+		font: inherit;
+		cursor: pointer;
+		outline: inherit;
+		appearance: none;
+
+		border-radius: 0.5rem;
+		padding: 0.5rem;
+
+		background-color: var(--red-500);
+		color: var(--background-color-secondary);
+		font-size: clamp(13px, 1.5vw, 15px);
+	}
+
+	 :global(.js-on) {
+    display: none; 
+  }
 </style>


### PR DESCRIPTION
## What does this change?

Resolves issue #59 #45 #177 #98 #28

#### Filter
De gradings kunnen worden gefilterd op "theme" en "status" en bevat
- op thema filteren
- op status filteren
- filteren op thema en status
- Een simpele transform animatie op de cards bij het filteren.
- Als Javascript uit staat werkt de filter nog met een submit button

#### Labels

- De label componenten worden automatisch op juiste status toegevoegd.

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- Tab en screenreader test: https://github.com/fdnd-agency/footguard/issues/177#issuecomment-3661009380
- PE: https://github.com/fdnd-agency/footguard/issues/177#issuecomment-3661064778
- Responsive en device test: https://github.com/fdnd-agency/footguard/issues/45#issuecomment-3463365433
- A11ly test: https://github.com/fdnd-agency/footguard/issues/45#issuecomment-3460296820
- Lighthouse test: https://github.com/fdnd-agency/footguard/issues/45#issuecomment-3460240285
- Performance test: https://github.com/fdnd-agency/footguard/issues/28#issuecomment-3460091773


## Images
<img width="1506" height="820" alt="Screenshot 2025-12-16 at 16 33 55" src="https://github.com/user-attachments/assets/5e16f33e-2f3e-4fb0-a7fc-a0198f9b05a3" />


https://github.com/user-attachments/assets/f96a36cf-f97e-4d7f-ae0a-fe8d50931a46




## How to review

- [ ] User test


## Opmerking

Er is nu nog een kleine bug dat ervoor zorgt dat de css styling van de select buttons weggaan als je de page refreshed. Als je navigeert naar een andere pagina en dan weer terug gebeurt dit niet. Ik heb hiervoor een issue gemaakt: #178. Dit los ik volgende sprint op.

 
