### PR TITLE
bug: added missing closing tag

### DIFF
--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -17,7 +17,7 @@
 :root {
     /* Typography */
     --main-font: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-
+}
 
 html,
 body {


### PR DESCRIPTION
## What does this change?

De Netlify-build kreeg een error omdat er een closing tag ontbrak in de globale stylesheet.

<img width="1210" height="421" alt="Screenshot 2025-12-18 at 01 43 19" src="https://github.com/user-attachments/assets/a8f10f78-28d5-4775-bb3c-b734eae78b11" />



Ik zet deze merge gelijk door.
