### PR TITLE
247 error fixen

### DIFF
--- a/src/lib/components/animations/PageLoader.svelte
+++ b/src/lib/components/animations/PageLoader.svelte
@@ -5,14 +5,17 @@
   // The whole loader container
   // De footguard logo element
   // The svg component element
-  let { mainContainer, logoFootGuard, svgElement } = $props();
+  let { mainContainer, svgElement } = $props();
 
   // Used sources: https://github.com/fdnd-agency/footguard/issues/155#issue-3702085279
 
   onMount(() => {
     // https://gsap.com/community/forums/topic/39201-best-practices-for-autoalpha-progressive-enhancement/
-    if (typeof window.gsap === "undefined") {
-      document.querySelector(".js").classList.toggle("js");
+    const window = globalThis
+    const document = globalThis.document
+
+    if (!window?.gsap) {
+    document?.querySelector('.js')?.classList.toggle('js')
     }
 
     gsap.fromTo(

--- a/src/lib/components/buttons/FilterButton.svelte
+++ b/src/lib/components/buttons/FilterButton.svelte
@@ -1,7 +1,7 @@
 <script>
 
   // dynamic data select button to reuse
-  let {labelText, selectValues, filterLabel_ID, className, form} = $props()
+  let {labelText, selectValues, filterLabel_ID} = $props()
 
 </script>
 
@@ -10,7 +10,7 @@
 <label for="{filterLabel_ID}" class="visually-hidden">{labelText}</label>
   <select id="{filterLabel_ID}" class="filter-button" name="filter">
 
-  {#each selectValues as selectValue}
+  {#each selectValues as selectValue (selectValue.value)}
     <option value={selectValue.value}>{selectValue.text}</option>
   {/each}
 </select>

--- a/src/lib/components/cards/PdfCard.svelte
+++ b/src/lib/components/cards/PdfCard.svelte
@@ -1,10 +1,7 @@
 <script>
     // Components
-    import QuestionFieldset from "$lib/components/form/QuestionFieldset.svelte";
-    import questionIcon from "$lib/assets/svg/round-question-icon.svg";
-    import Heading from "$lib/components/textual/Heading.svelte";
 
-    let { article, questions } = $props();
+    let { article } = $props();
 </script>
 
 <article class="pdf-container">

--- a/src/lib/components/cards/QuestionCard.svelte
+++ b/src/lib/components/cards/QuestionCard.svelte
@@ -1,6 +1,6 @@
 <script>
     // custom variables for reuse
-    const { questionAnswer, question, questionIcon, questionNumber } = $props();
+    const { question, questionNumber } = $props();
 </script>
 
 <div class="card-container">

--- a/src/lib/components/charts/CompareGradingTable.svelte
+++ b/src/lib/components/charts/CompareGradingTable.svelte
@@ -1,14 +1,8 @@
 <script>
-    import questionIcon from "$lib/assets/svg/round-question-icon.svg";
-    import question from "$lib/assets/svg/question.svg";
-    import plus from "$lib/assets/svg/plus-icon.svg";
     import minus from "$lib/assets/svg/minus-icon.svg";
 
     // Components
-    import QuestionFieldset from "$lib/components/form/QuestionFieldset.svelte";
-    import Heading from "$lib/components/textual/Heading.svelte";
     import QuestionCard from "$lib/components/cards/QuestionCard.svelte";
-    import QuestionsForm from "$lib/components/form/QuestionsForm.svelte";
     import GradingValue from "../textual/GradingValue.svelte";
 
     let { questions } = $props();
@@ -30,7 +24,7 @@
   </thead>
 
   <tbody>
-    {#each questions as question}
+    {#each questions as question (question.id)}
       <tr>
         <td class="question-cell">
           <QuestionCard question={question.question_title} questionIcon={minus} questionNumber={question.id}/>

--- a/src/lib/components/form/FilterForm.svelte
+++ b/src/lib/components/form/FilterForm.svelte
@@ -1,6 +1,5 @@
 <script>
     // Components
-    import FilterButton from "$lib/components/buttons/FilterButton.svelte";
 
     // Hiermee kan je custom events naar de parent page sturen in dit geval research
     import { createEventDispatcher } from "svelte";

--- a/src/lib/components/form/QuestionsForm.svelte
+++ b/src/lib/components/form/QuestionsForm.svelte
@@ -2,7 +2,6 @@
     // Components
     import QuestionFieldset from "$lib/components/form/QuestionFieldset.svelte";
     import questionIcon from "$lib/assets/svg/round-question-icon.svg";
-    import Heading from "$lib/components/textual/Heading.svelte";
 
     let { article, questions } = $props();
 </script>
@@ -17,7 +16,7 @@
 
 	<form class="questions-form" method="post">
         <div class="questions-scroll-container">
-            {#each questions as question }
+            {#each questions as question (question.id)}
                 <QuestionFieldset questionId={question.id} questionName={'question-' + question.id} questionTitle={question.question_title}/>
             {/each}
         </div>

--- a/src/lib/components/form/SearchBar.svelte
+++ b/src/lib/components/form/SearchBar.svelte
@@ -1,7 +1,7 @@
 <script>
 
     // dynamic data search input to reuse
-    let { searchBar_ID, labelText, className, form } = $props();
+    let { searchBar_ID, labelText } = $props();
 
 </script>
 

--- a/src/lib/components/textual/Heading.svelte
+++ b/src/lib/components/textual/Heading.svelte
@@ -1,6 +1,6 @@
 <script>
 
-  let {title, subTitle, className} = $props()
+  let {title, subTitle} = $props()
 
 </script>
 


### PR DESCRIPTION
## What does this change?

Resolves issue #247 

This change cleans up unused variables and props across multiple components to fix ESLint warnings (e.g. no-unused-vars, svelte/require-each-key, and svelte/no-navigation-without-resolve).
It improves code clarity and prevents build-time or CI warnings.

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] Manual UI test across affected components
- [ ] Lint and format pass in CI

## Images

Lint and format pass in CI


## How to review

- Open this branch
- Check with npm run lint

## Summary by Sourcery

Ruim ongebruikte props en imports op in verschillende Svelte-componenten en voer kleine aanpassingen in templates door om te voldoen aan ESLint- en Svelte-lintregels.

Bugfixes:
- Voeg ontbrekende keyed `each`-blocks toe in vraag- en filtergerelateerde componenten om svelte/require-each-key-waarschuwingen op te lossen.
- Beveilig GSAP-gerelateerde DOM-toegang tegen ongedefinieerde globals in de paginalader om runtime-fouten te voorkomen wanneer `gsap` niet aanwezig is.

Verbeteringen:
- Verwijder ongebruikte props en imports uit form-, button-, heading-, card- en chart-componenten om no-unused-vars-waarschuwingen te elimineren en de component-API’s te vereenvoudigen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up unused props and imports in several Svelte components and make small template adjustments to satisfy ESLint and Svelte linting rules.

Bug Fixes:
- Add missing keyed each-blocks in question- and filter-related components to resolve svelte/require-each-key warnings.
- Guard GSAP-related DOM access against undefined globals in the page loader to prevent runtime errors when gsap is not present.

Enhancements:
- Remove unused props and imports from form, button, heading, card, and chart components to eliminate no-unused-vars warnings and simplify component APIs.

</details>