### PR TITLE
268 prototype to html

### DIFF
--- a/src/lib/components/profile/ProfileHero.svelte
+++ b/src/lib/components/profile/ProfileHero.svelte
@@ -1,0 +1,6 @@
+
+<section >
+  <img alt="profile picture">
+  <h2>Dr. Jaap J. van Netten</h2>
+  <p>Onderzoekswetenschapper</p>
+</section>

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -13,7 +13,6 @@
     <dt>Email</dt><dd>Lorem ipsum</dd>
   </dl>
 
-  <a href="/profile">Groups</a>
-
+<a href={resolve('/')}>Groups</a>
 
 </section>

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -13,7 +13,7 @@
     <dt>Email</dt><dd>Lorem ipsum</dd>
   </dl>
 
-  <a href="/">Groups</a>
+  <a href="/profile">Groups</a>
 
 
 </section>

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -1,0 +1,19 @@
+<section>
+  <h2>General Information</h2>
+  <p>
+    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
+    the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley
+    of type and scrambled it to make a type specimen book.
+  </p>
+
+  <dl>
+    <dt>Role</dt><dd>Admin</dd>
+    <dt>Institution</dt><dd>Lorem ipsum</dd>
+    <dt>Name</dt><dd>Lorem ipsum</dd>
+    <dt>Email</dt><dd>Lorem ipsum</dd>
+  </dl>
+
+  <a href="/groups">Groups</a>
+
+
+</section>

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -13,7 +13,7 @@
     <dt>Email</dt><dd>Lorem ipsum</dd>
   </dl>
 
-  <a href="/groups">Groups</a>
+  <a href="/">Groups</a>
 
 
 </section>

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -1,3 +1,7 @@
+<script>
+  import { resolve } from '$app/paths'
+</script>
+
 <section>
   <h2>General Information</h2>
   <p>
@@ -13,6 +17,6 @@
     <dt>Email</dt><dd>Lorem ipsum</dd>
   </dl>
 
-<a href={resolve('/')}>Groups</a>
+  <a href={resolve('/')}>Groups</a>
 
 </section>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,0 +1,13 @@
+<script>
+  import ProfileHero from "$lib/components/profile/ProfileHero.svelte";
+  import ProfileInfo from "$lib/components/profile/ProfileInfo.svelte";
+</script>
+
+<section >
+  <h1>Profile</h1>
+
+  <article >
+    <ProfileHero />
+    <ProfileInfo />
+  </article>
+</section>


### PR DESCRIPTION
## What does this change?

Resolves issue #268 — translates the Figma prototype of the profile page into semantic HTML.

This PR adds two static HTML components:

- **Profile Hero** — image placeholder, name, and title.
- **Profile Info** — role, institution, name, and email, with a link to `/groups`.


## How Has This Been Tested?

- [x] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()



## How to review

1. Check out this branch and open the HTML files directly in a browser.
2. Check that the markup is semantic (correct use of headings, labels, etc.).