### PR TITLE
268 profile styling

### DIFF
--- a/src/lib/components/profile/ProfileHero.svelte
+++ b/src/lib/components/profile/ProfileHero.svelte
@@ -1,5 +1,5 @@
 <section class="profile-hero">
-  <img class="profile-avatar" src="..." alt="Dr. Jaap J. van Netten" />
+  <img class="profile-avatar" src="..." alt="avatar" />
     <div class="profile-copy">
     <h2>Dr. Jaap J. van Netten</h2>
     <p>Onderzoekswetenschapper</p>

--- a/src/lib/components/profile/ProfileHero.svelte
+++ b/src/lib/components/profile/ProfileHero.svelte
@@ -1,6 +1,77 @@
-
-<section >
-  <img alt="profile picture">
-  <h2>Dr. Jaap J. van Netten</h2>
-  <p>Onderzoekswetenschapper</p>
+<section class="profile-hero">
+  <img class="profile-avatar" src="..." alt="Dr. Jaap J. van Netten" />
+    <div class="profile-copy">
+    <h2>Dr. Jaap J. van Netten</h2>
+    <p>Onderzoekswetenschapper</p>
+  </div>
 </section>
+
+<style>
+  .profile-hero {
+    display: grid;
+    justify-items: center;
+    padding: 0 0 var(--spacing-lg);
+
+    &::before {
+      content: "";
+      width: 100%;
+      min-height: 8.5rem;
+      background: var(--blue-500);
+      border-radius: 0;
+      grid-column: 1;
+      grid-row: 1;
+    }
+
+    .profile-avatar {
+      width: 6rem;
+      height: 6rem;
+      border-radius: var(--radius-full);
+      border: 3px solid var(--background-color-primary);
+      background: linear-gradient(145deg, var(--green-200), var(--blue-300));
+      color: var(--background-color-primary);
+      display: grid;
+      place-items: center;
+      box-shadow: var(--shadow-sm);
+      grid-column: 1;
+      grid-row: 1;
+      align-self: end;
+      transform: translateY(50%);
+    }
+
+    .profile-copy {
+      margin-top: 3.5rem;
+      text-align: center;
+      padding-inline: var(--spacing-md);
+
+      h2 {
+        color: var(--blue-700);
+      }
+
+      p {
+        margin-top: 0.3rem;
+        color: var(--grey-400);
+      }
+    }
+  }
+
+  @container profile-card (min-width: 42rem) {
+    .profile-hero {
+      padding: var(--spacing-md) var(--spacing-md) var(--spacing-xl);
+
+      &::before {
+        min-height: 10rem;
+        border-radius: var(--radius-md);
+      }
+
+      .profile-avatar {
+        width: 7rem;
+        height: 7rem;
+      }
+
+      .profile-copy {
+        margin-top: 4rem;
+        padding-inline: var(--spacing-lg);
+      }
+    }
+  }
+</style>

--- a/src/lib/components/profile/ProfileHero.svelte
+++ b/src/lib/components/profile/ProfileHero.svelte
@@ -1,6 +1,6 @@
 <section class="profile-hero">
   <img class="profile-avatar" src="..." alt="avatar" />
-    <div class="profile-copy">
+  <div class="profile-info">
     <h2>Dr. Jaap J. van Netten</h2>
     <p>Onderzoekswetenschapper</p>
   </div>
@@ -38,7 +38,7 @@
       transform: translateY(50%);
     }
 
-    .profile-copy {
+    .profile-info {
       margin-top: 3.5rem;
       text-align: center;
       padding-inline: var(--spacing-md);
@@ -56,11 +56,11 @@
 
   @container profile-card (min-width: 42rem) {
     .profile-hero {
-      padding: var(--spacing-md) var(--spacing-md) var(--spacing-xl);
+      padding: 0 0 var(--spacing-xl);
 
       &::before {
         min-height: 10rem;
-        border-radius: var(--radius-md);
+        border-radius: 0;
       }
 
       .profile-avatar {
@@ -68,7 +68,7 @@
         height: 7rem;
       }
 
-      .profile-copy {
+      .profile-info {
         margin-top: 4rem;
         padding-inline: var(--spacing-lg);
       }

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -20,3 +20,62 @@
   <a href={resolve('/')}>Groups</a>
 
 </section>
+
+<style>
+  section {
+    padding: 0 var(--spacing-md) var(--spacing-xl);
+
+    h2 {
+      color: var(--blue-700);
+      margin-bottom: var(--spacing-md);
+    }
+
+    p {
+      color: var(--grey-400);
+      line-height: 1.7;
+      margin-bottom: var(--spacing-lg);
+    }
+
+    dl {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      row-gap: var(--spacing-md);
+      column-gap: var(--spacing-xl);
+      align-items: baseline;
+      margin-bottom: var(--spacing-xl);
+      margin-top:  var(--spacing-xl);
+
+      dt {
+        color: var(--grey-300);
+      }
+
+      dd {
+        color: var(--blue-600);
+        margin: 0;
+      }
+    }
+
+    a {
+      display: block;
+      width: fit-content;
+      margin-inline: auto;
+      padding: var(--spacing-sm) var(--spacing-xl);
+      border-radius: var(--radius-full);
+      background: var(--orange-400);
+      color: var(--background-color-primary);
+      text-align: center;
+    }
+  }
+
+  @container profile-card (min-width: 42rem) {
+    section {
+      padding: 0 var(--spacing-lg) var(--spacing-2xl);
+
+      dl {
+        grid-template-columns: auto 1fr auto 1fr;
+        column-gap: 4rem;
+        row-gap: var(--spacing-lg);
+      }
+    }
+  }
+</style>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -3,11 +3,44 @@
   import ProfileInfo from "$lib/components/profile/ProfileInfo.svelte";
 </script>
 
-<section >
-  <h1>Profile</h1>
+<section class="profile-page">
+  <h1 class="profile-title">Profile</h1>
 
-  <article >
+  <article class="profile-card">
     <ProfileHero />
     <ProfileInfo />
   </article>
 </section>
+
+<style>
+  .profile-page {
+    min-height: 100vh;
+    background: var(--grey-100);
+    padding: var(--spacing-lg) var(--spacing-md) var(--spacing-2xl);
+
+    .profile-title {
+      color: var(--blue-700);
+      margin-bottom: var(--spacing-md);
+    }
+
+    .profile-card {
+      background: var(--background-color-primary);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-sm);
+      overflow: hidden;
+      container-type: inline-size;
+      container-name: profile-card;
+    }
+  }
+
+  @media (min-width: 42rem) {
+    .profile-page {
+      padding: var(--spacing-xl);
+
+      .profile-card {
+        max-width: 100%;
+        margin-inline: auto;
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
## What does this change?

Resolves issue #268

This PR refines the profile UI styling and responsive behavior.

### Why this change is needed
The profile page had layout inconsistencies between mobile and desktop:
- Hero section spacing/padding differed across breakpoints
- Avatar overlap and alignment needed cleanup
- Info section needed clearer responsive grid behavior

### What was changed

- **`ProfileHero.svelte components`**
  - Improved avatar alignment and overlap behavior
  - Improved name/title spacing and visual hierarchy
  - Added/updated container-query behavior for larger viewpoin

- **`ProfileInfo.svelte components `**
  - Refined details section spacing and hierarchy
  - Kept `dl` structure and improved responsive grid layout
  - Added desktop container-query layout improvements

- **`/profile/+page.svelte`**
  - Updated profile page/card shell CSS
  - Improved responsive spacing and breakpoint behavior


## How Has This Been Tested?

- [x] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images

### Mobile:
<img width="314" height="629" alt="Screenshot 2026-03-04 at 13 03 09" src="https://github.com/user-attachments/assets/7081e123-6bdc-46da-a86a-c506ac56ad8b" />

<hr>

### Desktop:
<img width="1210" height="752" alt="Screenshot 2026-03-04 at 13 02 44" src="https://github.com/user-attachments/assets/604a2886-777a-440d-8b6b-d8e22a52e3af" />

## How to review

1. Checkout this branch and run the app.
2. Open `/profile`.
3. Verify on mobile width:
   - Hero banner fills correctly
   - Avatar overlap is centered and not clipped
   - Name/title spacing matches design intent
   - Info list is readable in single-column layout
4. Verify on desktop width:
   - Hero remains visually consistent with mobile style
   - Info section uses the intended multi-column responsive layout
   - Spacing, colors, radius, and shadows align with styleguide.
