### PR TITLE
254 feature role based access control

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -65,5 +65,29 @@ export const handle: Handle = async ({ event, resolve }) => {
     throw redirect(302, '/login')
   }
 
+  // Role-based access control
+  const adminOnlyPaths = ['/admin']
+  const assessorPaths = ['/research', '/results']
+
+  const path = event.url.pathname
+
+  // not logged in -> redirect to login
+  if (!event.locals.user) {
+    const protectedPaths = ['/admin', '/research', '/results', '/profile', '/notifications']
+    if (protectedPaths.some((p) => path.startsWith(p))) {
+      throw redirect(302, '/login')
+    }
+  }
+
+  // Logged in but wrong role
+  if (event.locals.user) {
+    const role = event.locals.user.role
+
+    //Only super_admin and admin can access /admin
+    if (path.startsWith('/admin') && role !== 'super_admin' && role !== 'admin') {
+      throw redirect(302, '/')
+    }
+  }
+
   return resolve(event)
 }

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -1,0 +1,5 @@
+export function load({ locals }) {
+  return {
+    user: locals.user ?? null
+  }
+}

--- a/src/routes/admin/+layout.server.js
+++ b/src/routes/admin/+layout.server.js
@@ -1,0 +1,17 @@
+import { redirect } from '@sveltejs/kit'
+
+export function load({ locals }) {
+  // Retrieve the authenticated user from locals
+  const user = locals.user
+
+  // If there is no logged-in user, redirect to the login page
+  if (!user) throw redirect(302, '/login')
+
+  // Check if the user has the required role (admin or super_admin)
+  // If not, redirect them to the homepage
+  if (user.role !== 'super_admin' && user.role !== 'admin') {
+    throw redirect(302, '/')
+  }
+  // Return the user object so it can be used in the page
+  return { user }
+}

--- a/src/routes/login/magic-login/+server.js
+++ b/src/routes/login/magic-login/+server.js
@@ -54,7 +54,6 @@ export async function GET({ url, cookies }) {
   })
 
   if (!patchRes.ok) {
-    const patchData = await patchRes.json().catch(() => ({}))
     throw redirect(302, '/login')
   }
 

--- a/src/routes/research/+layout.server.js
+++ b/src/routes/research/+layout.server.js
@@ -1,0 +1,14 @@
+import { redirect } from '@sveltejs/kit'
+
+export function load({ locals }) {
+  // Retrieve the authenticated user from the request locals
+  const user = locals.user
+
+  // If no user is logged in, redirect to the login page
+  if (!user) throw redirect(302, '/login')
+
+  // All authenticated users are allowed to access the research section.
+  // More specific permission checks or data filtering are handled
+  // inside the individual pages of this section.
+  return { user }
+}

--- a/src/routes/research/[article_id]/+page.server.js
+++ b/src/routes/research/[article_id]/+page.server.js
@@ -1,6 +1,13 @@
-export async function load({ fetch, params }) {
+import { redirect, error } from '@sveltejs/kit'
+
+export async function load({ fetch, params, locals }) {
+  // Retrieve the authenticated user from locals
+  const user = locals.user
+
+  // Get the article ID from the route parameters
   const articleId = params.article_id
 
+  // Fetch the article details from the Directus API
   const detailsResponse = await fetch(
     'https://fdnd-agency.directus.app/items/footguard_articles/' + articleId
   )
@@ -8,12 +15,28 @@ export async function load({ fetch, params }) {
 
   let detailsInfo = detailsData.data
 
+  // Toegangscheck op basis van rol
+  if (!detailsInfo) throw error(404, 'Article not found')
+
+  // Access control based on user role:
+  // Assessors can only access articles assigned to their email
+  if (user.role === 'assessor' && detailsInfo.assigned_to !== user.email) {
+    throw redirect(302, '/research')
+  }
+
+  // Admins can only access articles within their own workgroup
+  if (user.role === 'admin' && detailsInfo.workgroup !== user.workgroup) {
+    throw redirect(302, '/research')
+  }
+
   const questionResponse = await fetch(
     'https://fdnd-agency.directus.app/items/footguard_checklists'
   )
   const questionData = await questionResponse.json()
 
+  // Extract checklist data from the response
   let questionInfo = questionData.data
 
+  // Return the fetched data so it can be used in the page
   return { questionInfo, detailsInfo }
 }


### PR DESCRIPTION
## What does this change?

Resolves issue #254 

This PR adds role-based access control to the Footguard application. Previously, all authenticated users could access any route or article regardless of their role. This change restricts access based on three roles:

- Super admin can access all data and routes
- Admin can only access articles within their own workgroup
- Assessor can only access articles that are assigned to them

This is implemented using locals.user (set in hooks.server.ts) combined with load() functions in layout and page server files.

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ]  Logged out user trying to access /research → redirected to /login
- [ ]  Assessor trying to access /admin → redirected to /
- [ ]  Assessor trying to access an article not assigned to them → redirected to /research
- [ ]  Admin trying to access an article from a different workgroup → redirected to /research
- [ ]  Super admin accessing all routes → full access confirmed

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

1. Check out this branch locally
2. Log in as an assessor account
3. Try navigating to /admin → you should be redirected to /
4. Try navigating to /research/[article_id] of an article not assigned to you → redirected to /research
5. Log in as super_admin → verify full access to all routes and articles
