### PR TITLE
feat: make GroupsLink component for ProfileForm #278

### DIFF
--- a/src/lib/components/profile/GroupsLink.svelte
+++ b/src/lib/components/profile/GroupsLink.svelte
@@ -1,0 +1,24 @@
+<script>
+  import { resolve } from '$app/paths'
+</script>
+
+<a href={resolve('/groups')}>Groups</a>
+
+<style>
+  a {
+    display: block;
+    width: fit-content;
+    margin-inline: auto;
+    padding: var(--spacing-sm) var(--spacing-xl);
+    border-radius: var(--radius-full);
+    background: var(--orange-400);
+    color: var(--background-color-primary);
+    text-align: center;
+  
+    &:focus-visible {
+      outline: 3px solid var(--blue-500);
+      outline-offset: 2px;
+      border-radius: var(--radius-sm);
+    }
+  }
+</style>

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -27,7 +27,7 @@
       <span>Email</span>
       <input id="info-email" type="text" readonly value={user?.email ?? "Unknown"} />
     </label>
-  </form>
+  <GroupsLink />
 
   <GroupsLink />
 

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -29,7 +29,7 @@
     </label>
   </form>
 
-  <GroupsLinkButton />
+  <GroupsLink />
 
 </section>
 

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -1,5 +1,5 @@
 <script>
-  import GroupsLinkButton from '$lib/components/profile/GroupsLink.svelte'
+  import GroupsLink from '$lib/components/profile/GroupsLink.svelte'
   let { user } = $props();
   const roleText = $derived(
     Array.isArray(user?.role) ? user.role.join(", ") : (user?.role ?? "Unknown")

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -1,5 +1,5 @@
 <script>
-  import GroupsLinkButton from '$lib/components/profile/GroupsLinkButton.svelte'
+  import GroupsLinkButton from '$lib/components/profile/GroupsLink.svelte'
   let { user } = $props();
   const roleText = $derived(
     Array.isArray(user?.role) ? user.role.join(", ") : (user?.role ?? "Unknown")

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -1,8 +1,9 @@
 <script>
-  import { resolve } from '$app/paths'
+  import GroupsLinkButton from '$lib/components/profile/GroupsLinkButton.svelte'
   let { user } = $props();
-  const role = user?.role;
-  const roleText = Array.isArray(role) ? role.join(", ") : (role ?? "Unknown");
+  const roleText = $derived(
+    Array.isArray(user?.role) ? user.role.join(", ") : (user?.role ?? "Unknown")
+  );
 </script>
 
 <section>
@@ -28,7 +29,7 @@
     </label>
   </form>
 
-  <a href={resolve('/')}>Groups</a>
+  <GroupsLinkButton />
 
 </section>
 
@@ -39,12 +40,6 @@
     h2 {
       color: var(--blue-700);
       margin-bottom: var(--spacing-md);
-    }
-
-    p {
-      color: var(--grey-400);
-      line-height: 1.7;
-      margin-bottom: var(--spacing-lg);
     }
 
     .info-grid {
@@ -77,22 +72,6 @@
       }
     }
 
-    a {
-      display: block;
-      width: fit-content;
-      margin-inline: auto;
-      padding: var(--spacing-sm) var(--spacing-xl);
-      border-radius: var(--radius-full);
-      background: var(--orange-400);
-      color: var(--background-color-primary);
-      text-align: center;
-    }
-
-    a:focus-visible {
-      outline: 3px solid var(--blue-500);
-      outline-offset: 2px;
-      border-radius: var(--radius-sm);
-    }
   }
 
   @container profile-card (min-width: 42rem) {


### PR DESCRIPTION


## What does this change?

Resolves issue #1337

Previously the Profile page had an inline `<a>` tag linking to the Groups page directly inside `ProfileForm`. 
After the sprint review and team talk discussion, we decided Groups should have its own separate page instead of being displayed on the Profile page.
[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images

<img width="396" height="845" alt="Screenshot 2026-03-13 at 00 50 43" src="https://github.com/user-attachments/assets/f6ae2555-0426-4395-9da2-89cb0b606042" />
<img width="243" height="78" alt="Screenshot 2026-03-13 at 00 51 00" src="https://github.com/user-attachments/assets/edc23f19-4daf-4124-b972-43b32d69c23a" />


## How to review


On this branch, navigate to `/profile` and verify:
- GroupsLinkButton renders.
- Clicking it navigates to `/groups`
- Tab to the button and verify focus outline is visible