### PR TITLE
fix: delete extra button in the profile page #294

### DIFF
--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -29,7 +29,6 @@
     </label>
   <GroupsLink />
 
-  <GroupsLink />
 
 </section>
 


### PR DESCRIPTION

## What does this change?

Resolves issue #294 

I deleted the extra button that was in the profile page.


## How Has This Been Tested?

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()


## How to review
Go to this branch,
Go to the profile page and check the groups link. 
There should be only one now showing
