### PR TITLE
296 bug magic link not working on production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 DIRECTUS_TOKEN=
-PUBLIC_APP_URL=http://localhost:5173
-EMAIL_PROVIDER=console
-MAIL_FROM=no-reply@iwgdfguidelines.org
+PUBLIC_APP_URL=https://footguard.dev.fdnd.nl
+EMAIL_PROVIDER=resend
+MAIL_FROM=no-reply@fdnd.nl

--- a/src/lib/server/email.js
+++ b/src/lib/server/email.js
@@ -40,10 +40,31 @@ export async function sendMagicLinkEmail({ to, link }) {
       to,
       subject: 'Your Magic Login Link(valid for 15 minutes)',
       html: `
-            <p>Hello,</p>
-            <p>Click the link below to log in (valid for 15 minutes):</p>
-            <p><a href="${link}">Sign in</a></p>
-            <p>If you did not request this, you can ignore this email.</p>
+            <div style="font-family: Arial, sans-serif; max-width: 480px; margin: 0 auto; padding: 32px; background-color: #f9f9f9; border-radius: 8px;">
+    
+    <h2 style="color: #1a1a1a; margin-bottom: 8px;">Sign in to IWGDF Guidelines</h2>
+    
+    <p style="color: #444; font-size: 15px; line-height: 1.6;">
+      You requested a sign-in link for your IWGDF account. Click the button below to log in.
+      This link is valid for <strong>15 minutes</strong> and can only be used once.
+    </p>
+       <div style="text-align: center; margin: 32px 0;">
+      <a href="${link}" style="background-color: #1a6fc4; color: #ffffff; padding: 14px 28px; border-radius: 6px; text-decoration: none; font-size: 16px; font-weight: bold;">
+        Sign in to IWGDF
+      </a>
+    </div>
+
+    <p style="color: #888; font-size: 13px; line-height: 1.6;">
+      If you did not request this email, you can safely ignore it. Your account remains secure.
+    </p>
+
+    <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 24px 0;" />
+    
+    <p style="color: #aaa; font-size: 12px; text-align: center;">
+      &copy; IWGDF Guidelines &nbsp;|&nbsp; This is an automated message, please do not reply.
+    </p>
+
+  </div>
         `
     })
 

--- a/src/routes/login/api/magic-link/+server.js
+++ b/src/routes/login/api/magic-link/+server.js
@@ -2,6 +2,7 @@
 import { json } from '@sveltejs/kit'
 import crypto from 'crypto'
 import { env } from '$env/dynamic/private'
+import { env as publicEnv } from '$env/dynamic/public'
 import { sendMagicLinkEmail } from '$lib/server/email'
 
 const DIRECTUS_URL = 'https://fdnd-agency.directus.app'
@@ -134,7 +135,7 @@ export async function POST({ request, getClientAddress, url }) {
     }
 
     // --- 4) Build magic link from env (no hardcoded localhost) ---
-    const appUrl = env.PUBLIC_APP_URL || url.origin
+    const appUrl = publicEnv.PUBLIC_APP_URL || url.origin
     const magicLink = `${appUrl}/login/magic-login?token=${rawToken}`
 
     // --- 5) Send email (dev fallback logs to console) ---


### PR DESCRIPTION
## What does this change?

Resolves issue #296

This PR fixes two bugs in the magic link login flow that prevented users from logging in on production (https://footguard.dev.fdnd.nl).
Fix 1 — Wrong environment variable import
PUBLIC_APP_URL was imported via $env/dynamic/private, but PUBLIC_ variables must come from $env/dynamic/public. This caused the POST endpoint to crash with a 500 error on production, so no magic link email was ever sent.
Fix 2 — Updated email template
The magic link email has been updated with a professional IWGDF branded design, including a styled button, clear instructions, and a footer.

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]() tested locally on Chrome, magic link email received and login flow works correctly on localhost

## Images

Email before: Plain text, unstyled, generic message.
<img width="584" height="382" alt="Screenshot 2026-03-14 at 15 18 51" src="https://github.com/user-attachments/assets/ed44d641-5c6d-47f0-b73a-7efda3806431" />

Email after: IWGDF branded email with blue button, clear instructions and professional footer.
<img width="585" height="502" alt="Screenshot 2026-03-14 at 15 19 26" src="https://github.com/user-attachments/assets/127c3e41-21e5-4365-b87d-2c4effd1d50b" />


## How to review

1. On dev branch, go to https://footguard.dev.fdnd.nl/login
2. Fill in a valid email address and click "Send magic link"
3. Check your inbox — you should receive a styled IWGDF email
4. Click the button in the email — you should be redirected to the dashboard
