### PR TITLE
fix: remove unused publicEnv import and use url.origin for magic link…

### DIFF
--- a/src/routes/login/api/magic-link/+server.js
+++ b/src/routes/login/api/magic-link/+server.js
@@ -2,7 +2,6 @@
 import { json } from '@sveltejs/kit'
 import crypto from 'crypto'
 import { env } from '$env/dynamic/private'
-import { env as publicEnv } from '$env/dynamic/public'
 import { sendMagicLinkEmail } from '$lib/server/email'
 
 const DIRECTUS_URL = 'https://fdnd-agency.directus.app'
@@ -135,7 +134,7 @@ export async function POST({ request, getClientAddress, url }) {
     }
 
     // --- 4) Build magic link from env (no hardcoded localhost) ---
-    const appUrl = publicEnv.PUBLIC_APP_URL || url.origin
+    const appUrl = url.origin
     const magicLink = `${appUrl}/login/magic-login?token=${rawToken}`
 
     // --- 5) Send email (dev fallback logs to console) ---


### PR DESCRIPTION

## What does this change?

Resolves issue #300
Removed unused publicEnv import and replaced PUBLIC_APP_URL with url.origin in src/routes/login/api/magic-link/+server.js.
This means the magic link URL now works automatically in every environment — no .env configuration needed. Previously, developers had to manually set PUBLIC_APP_URL in their .env file, otherwise the magic link would point to the wrong URL.
(http://localhost:5173/)


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()  tested locally on Chrome, magic link email received and login works correctly on localhost

## Images

No UI changes.


## How to review

1. On dev branch, go to http://localhost:5173/login
2. Fill in a valid email and click "Send magic link"
3. Check your inbox — the link in the email should point to http://localhost:5173
4. Click the link — you should be redirected to the dashboard

