### PR TITLE
310 user story years filter for group page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DIRECTUS_TOKEN=
+PUBLIC_DIRECTUS_URL=https://fdnd-agency.directus.app
 PUBLIC_APP_URL=https://footguard.dev.fdnd.nl
 EMAIL_PROVIDER=resend
 MAIL_FROM=no-reply@fdnd.nl

--- a/package-lock.json
+++ b/package-lock.json
@@ -4100,24 +4100,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",

--- a/src/lib/components/groupFilter/GroupFilter.svelte
+++ b/src/lib/components/groupFilter/GroupFilter.svelte
@@ -1,3 +1,7 @@
+<script>
+  import DetailsUpIcon from "$lib/assets/svg/DetailsUpIcon.svelte";
+</script>
+
 <form class="select-wrap" method="GET" action="/groups">
       <select
         name="year"
@@ -7,6 +11,9 @@
         <option value="2023">Guidelines 2023</option>
         <option value="2027">Guidelines 2027</option>
       </select>
+      <span class="chevron" aria-hidden="true">
+        <DetailsUpIcon />
+      </span>
 </form>
 
 <style>
@@ -35,19 +42,36 @@
         appearance: base-select;
     }
 
-    /* Select: custom picker arrow icon */
+    /* Select: hide native picker icon (we render shared icon in markup) */
     select::picker-icon {
-        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='18 15 12 9 6 15'/%3E%3C/svg%3E");
-        width: 1rem;
-        height: 1rem;
-        color: var(--grey-600);
-        transform-origin: center;
-        transition: transform 220ms ease;
+      display: none;
+    }
+
+    .chevron {
+      position: absolute;
+      right: var(--spacing-sm);
+      top: 50%;
+      transform: translateY(-50%);
+      display: inline-flex;
+      color: var(--grey-600);
+      pointer-events: none;
+      transition: transform 220ms ease;
     }
 
     /* Select: rotate arrow when dropdown is open */
-    select:open::picker-icon {
-      transform: rotate(180deg);
+    .select-wrap:has(select:open) .chevron {
+      transform: translateY(-50%) rotate(180deg);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .chevron {
+        transition: none;
+      }
+    }
+
+    /* Keep text clear from custom chevron */
+    select {
+      padding-right: calc(var(--spacing-sm) * 2 + 1rem);
     }
 
     /* Select: dropdown panel styles */
@@ -61,28 +85,29 @@
     }
 
     /* Select: option styles to match field */
-    option {
-      border: none;
-      border-radius: var(--radius-sm);
-      color: var(--grey-700);
-      background: var(--background-color-primary);
-      padding: var(--spacing-xs) var(--spacing-sm);
+  option {
+    border: none;
+    border-radius: var(--radius-sm);
+    color: var(--grey-700);
+    background: var(--background-color-primary);
+    padding: var(--spacing-xs) var(--spacing-sm);
+
+    &:hover,
+    &:focus-visible {
+      background: var(--grey-50);
     }
 
-    option:hover,
-    option:focus-visible {
-        background: var(--grey-50);
-  }
-
-    option:checked {
-        background: var(--green-100);
-        color: var(--green-700);
-        font-weight: var(--font-weight-bold);
-  }
+    &:checked {
+      background: var(--green-100);
+      color: var(--green-700);
+      font-weight: var(--font-weight-bold);
+    }
 
   /* Select: hide default selected checkmark icon */
-    option::checkmark {
-        display: none;
+    &::checkmark {
+      display: none;
     }
+}
+
 
 </style>

--- a/src/lib/components/groupFilter/GroupFilter.svelte
+++ b/src/lib/components/groupFilter/GroupFilter.svelte
@@ -1,0 +1,88 @@
+<form class="select-wrap" method="GET" action="/groups">
+      <select
+        name="year"
+        aria-label="Select guideline year"
+        onchange={(event) => event.currentTarget.form?.requestSubmit()}>
+        <option value="" selected disabled hidden>Guidelines</option>
+        <option value="2023">Guidelines 2023</option>
+        <option value="2027">Guidelines 2027</option>
+      </select>
+</form>
+
+<style>
+    .select-wrap {
+        width: min(100%, 20rem);
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+    }
+
+    /* Select: field styles */
+    select {
+        width: 100%;
+        padding: var(--spacing-xs) var(--spacing-sm);
+        border-radius: var(--radius-md);
+        color: var(--grey-700);
+        font-size: var(--font-size-base);
+        border: none;
+        cursor: pointer;
+        box-shadow: 0 4px 14px 0 rgba(0, 0, 0, 0.10);
+    }
+
+    /* Select: enable customizable picker UI */
+    select,
+    ::picker(select) {
+        appearance: base-select;
+    }
+
+    /* Select: custom picker arrow icon */
+    select::picker-icon {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='18 15 12 9 6 15'/%3E%3C/svg%3E");
+        width: 1rem;
+        height: 1rem;
+        color: var(--grey-600);
+        transform-origin: center;
+        transition: transform 220ms ease;
+    }
+
+    /* Select: rotate arrow when dropdown is open */
+    select:open::picker-icon {
+      transform: rotate(180deg);
+    }
+
+    /* Select: dropdown panel styles */
+    ::picker(select) {
+        border: none;
+        border-radius: var(--radius-md);
+        background: var(--background-color-primary);
+        box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.12);
+        margin-top: var(--spacing-xxs);
+        padding: var(--spacing-xxs);
+    }
+
+    /* Select: option styles to match field */
+    option {
+      border: none;
+      border-radius: var(--radius-sm);
+      color: var(--grey-700);
+      background: var(--background-color-primary);
+      padding: var(--spacing-xs) var(--spacing-sm);
+    }
+
+    option:hover,
+    option:focus-visible {
+        background: var(--grey-50);
+  }
+
+    option:checked {
+        background: var(--green-100);
+        color: var(--green-700);
+        font-weight: var(--font-weight-bold);
+  }
+
+  /* Select: hide default selected checkmark icon */
+    option::checkmark {
+        display: none;
+    }
+
+</style>

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -102,7 +102,6 @@
   /* Typography */
   --main-font: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
 
-  
   /* Primary blue colors */
   --blue-700: hsl(203, 90%, 22%);
   --blue-600: hsl(203, 85%, 32%);
@@ -188,8 +187,8 @@
   --transition-base: 0.2s ease;
   --transition-slow: 0.3s ease;
 
-    /* Form input size for mobile devices */
-    --form-mobile-input-size: 16px;
+  /* Form input size for mobile devices */
+  --form-mobile-input-size: 16px;
 }
 
 html {

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -102,6 +102,7 @@
   /* Typography */
   --main-font: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
 
+  
   /* Primary blue colors */
   --blue-700: hsl(203, 90%, 22%);
   --blue-600: hsl(203, 85%, 32%);
@@ -186,6 +187,9 @@
   --transition-fast: 0.15s ease;
   --transition-base: 0.2s ease;
   --transition-slow: 0.3s ease;
+
+    /* Form input size for mobile devices */
+    --form-mobile-input-size: 16px;
 }
 
 html {
@@ -280,6 +284,7 @@ input,
 textarea,
 select {
   font-family: inherit;
+  font-size: var(--form-mobile-input-size);
 }
 
 .skip-link {

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import GroupAboutBanner from "$lib/components/groups/GroupAboutBanner.svelte";
   import GroupCard from "$lib/components/groups/GroupCard.svelte";
+  import GroupFilter from "$lib/components/groupFilter/GroupFilter.svelte"
 </script>
 
 <section class="groups-page">
@@ -8,21 +9,11 @@
 
   <article class="groups-intro">
       <!-- TODO: Move banner content source to directus data fields and remove fallback text. --> 
-      <!-- TODO: Replace this placeholder banner with dynamic data from the group data. -->       
+      <!-- TODO: Replace this placeholder banner with dynamic data from the group data. -->   
     <GroupAboutBanner>
       Manage members, invite users by email, and quickly update group access.
     </GroupAboutBanner>
-    <form class="select-wrap" method="GET" action="/groups">
-      <select
-        name="year"
-        aria-label="Select guideline year"
-        onchange={(event) => event.currentTarget.form?.requestSubmit()}
-      >
-        <option value="" selected disabled hidden>Guidelines</option>
-        <option value="2023">Guidelines 2023</option>
-        <option value="2027">Guidelines 2027</option>
-      </select>
-    </form>
+    <GroupFilter />
     <div class="groups-cards">
       <GroupCard />
     </div>
@@ -30,82 +21,6 @@
 </section>
 
 <style>
-  /* Select: layout container */
-  .select-wrap {
-    width: min(100%, 20rem);
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-  }
-
-  /* Select: field styles */
-  select {
-    width: 100%;
-    padding: var(--spacing-xs) var(--spacing-sm);
-    border-radius: var(--radius-md);
-    color: var(--grey-700);
-    font-size: var(--font-size-base);
-    border: none;
-    cursor: pointer;
-    box-shadow: 0 4px 14px 0 rgba(0, 0, 0, 0.10);
-  }
-
-  /* Select: enable customizable picker UI */
-  select,
-  ::picker(select) {
-    appearance: base-select;
-  }
-
-  /* Select: custom picker arrow icon */
-  select::picker-icon {
-    content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='18 15 12 9 6 15'/%3E%3C/svg%3E");
-    width: 1rem;
-    height: 1rem;
-    color: var(--grey-600);
-    transform-origin: center;
-    transition: transform 220ms ease;
-  }
-
-  /* Select: rotate arrow when dropdown is open */
-  select:open::picker-icon {
-    transform: rotate(180deg);
-  }
-
-  /* Select: dropdown panel styles */
-  ::picker(select) {
-    border: none;
-    border-radius: var(--radius-md);
-    background: var(--background-color-primary);
-    box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.12);
-    margin-top: var(--spacing-xxs);
-    padding: var(--spacing-xxs);
-  }
-
-  /* Select: option styles to match field */
-  option {
-    border: none;
-    border-radius: var(--radius-sm);
-    color: var(--grey-700);
-    background: var(--background-color-primary);
-    padding: var(--spacing-xs) var(--spacing-sm);
-  }
-
-  option:hover,
-  option:focus-visible {
-    background: var(--grey-50);
-  }
-
-  option:checked {
-    background: var(--green-100);
-    color: var(--green-700);
-    font-weight: var(--font-weight-bold);
-  }
-
-  /* Select: hide default selected checkmark icon */
-  option::checkmark {
-    display: none;
-  }
-
   .groups-page {
     min-height: 100%;
     display: grid;

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -12,6 +12,17 @@
     <GroupAboutBanner>
       Manage members, invite users by email, and quickly update group access.
     </GroupAboutBanner>
+    <form class="select-wrap" method="GET" action="/groups">
+      <select
+        name="year"
+        aria-label="Select guideline year"
+        onchange={(event) => event.currentTarget.form?.requestSubmit()}
+      >
+        <option value="" selected disabled hidden>Guidelines</option>
+        <option value="2023">Guidelines 2023</option>
+        <option value="2027">Guidelines 2027</option>
+      </select>
+    </form>
     <div class="groups-cards">
       <GroupCard />
     </div>
@@ -19,6 +30,82 @@
 </section>
 
 <style>
+  /* Select: layout container */
+  .select-wrap {
+    width: min(100%, 20rem);
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* Select: field styles */
+  select {
+    width: 100%;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--radius-md);
+    color: var(--grey-700);
+    font-size: var(--font-size-base);
+    border: none;
+    cursor: pointer;
+    box-shadow: 0 4px 14px 0 rgba(0, 0, 0, 0.10);
+  }
+
+  /* Select: enable customizable picker UI */
+  select,
+  ::picker(select) {
+    appearance: base-select;
+  }
+
+  /* Select: custom picker arrow icon */
+  select::picker-icon {
+    content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='18 15 12 9 6 15'/%3E%3C/svg%3E");
+    width: 1rem;
+    height: 1rem;
+    color: var(--grey-600);
+    transform-origin: center;
+    transition: transform 220ms ease;
+  }
+
+  /* Select: rotate arrow when dropdown is open */
+  select:open::picker-icon {
+    transform: rotate(180deg);
+  }
+
+  /* Select: dropdown panel styles */
+  ::picker(select) {
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--background-color-primary);
+    box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.12);
+    margin-top: var(--spacing-xxs);
+    padding: var(--spacing-xxs);
+  }
+
+  /* Select: option styles to match field */
+  option {
+    border: none;
+    border-radius: var(--radius-sm);
+    color: var(--grey-700);
+    background: var(--background-color-primary);
+    padding: var(--spacing-xs) var(--spacing-sm);
+  }
+
+  option:hover,
+  option:focus-visible {
+    background: var(--grey-50);
+  }
+
+  option:checked {
+    background: var(--green-100);
+    color: var(--green-700);
+    font-weight: var(--font-weight-bold);
+  }
+
+  /* Select: hide default selected checkmark icon */
+  option::checkmark {
+    display: none;
+  }
+
   .groups-page {
     min-height: 100%;
     display: grid;

--- a/src/routes/profile/+layout.server.js
+++ b/src/routes/profile/+layout.server.js
@@ -1,0 +1,8 @@
+import { redirect } from '@sveltejs/kit'
+
+// Redirect to login if not authenticated; applies to all /profile/* routes.
+export function load({ locals }) {
+  const user = locals.user
+  if (!user) throw redirect(302, '/login')
+  return { user }
+}

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -1,10 +1,10 @@
 export async function load({ fetch, locals }) {
   const sessionUser = locals.user
 
-  // Fetch users from Directus filtered by the logged-in user's email.
+  // Fetch user from Directus by exact email match.
   const usersResponse = await fetch(
     'https://fdnd-agency.directus.app/items/footguard_users?' +
-      `filter[email][_icontains]=${encodeURIComponent(sessionUser.email)}&limit=1`
+      `filter[email][_eq]=${encodeURIComponent(sessionUser.email)}&limit=1`
   )
 
   if (!usersResponse.ok) {

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -1,6 +1,19 @@
-export async function load({ fetch }) {
-  const userDetailsResponse = await fetch('https://fdnd-agency.directus.app/items/footguard_users/')
-  const userDetailsData = await userDetailsResponse.json()
-  let userInfo = userDetailsData.data
-  return { userInfo }
+export async function load({ fetch, locals }) {
+  const sessionUser = locals.user
+
+  // Fetch users from Directus filtered by the logged-in user's email.
+  const usersResponse = await fetch(
+    'https://fdnd-agency.directus.app/items/footguard_users?' +
+      `filter[email][_icontains]=${encodeURIComponent(sessionUser.email)}&limit=1`
+  )
+
+  if (!usersResponse.ok) {
+    return { user: sessionUser }
+  }
+
+  // Parse the Directus response; the users array lives in the .data property.
+  const usersResult = await usersResponse.json()
+  const [user] = usersResult?.data ?? []
+
+  return { user: user ?? sessionUser }
 }

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -1,9 +1,13 @@
+import { env } from '$env/dynamic/public'
+
+const DIRECTUS_URL = env.PUBLIC_DIRECTUS_URL || 'https://fdnd-agency.directus.app'
+
 export async function load({ fetch, locals }) {
   const sessionUser = locals.user
 
   // Fetch user from Directus by exact email match.
   const usersResponse = await fetch(
-    'https://fdnd-agency.directus.app/items/footguard_users?' +
+    `${DIRECTUS_URL}/items/footguard_users?` +
       `filter[email][_eq]=${encodeURIComponent(sessionUser.email)}&limit=1`
   )
 

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -4,7 +4,7 @@
   import ProfileHero from "$lib/components/profile/ProfileHero.svelte";
   import ProfileInfo from "$lib/components/profile/ProfileInfo.svelte";
   let { data } = $props();
-  const user = data.userInfo?.[0];
+  const user = $derived(data.user);
 </script>
 
 

--- a/src/routes/profile/[user_id]/+page.server.js
+++ b/src/routes/profile/[user_id]/+page.server.js
@@ -1,13 +1,14 @@
 import { error } from '@sveltejs/kit'
+import { env } from '$env/dynamic/public'
+
+const DIRECTUS_URL = env.PUBLIC_DIRECTUS_URL || 'https://fdnd-agency.directus.app'
 
 // Runs on the server before rendering this dynamic profile page.
 export async function load({ fetch, params }) {
   // Grab the dynamic route param.
   const userId = params.user_id
   // Request the profile record for the requested user id from Directus.
-  const userResponse = await fetch(
-    'https://fdnd-agency.directus.app/items/footguard_users/' + userId
-  )
+  const userResponse = await fetch(`${DIRECTUS_URL}/items/footguard_users/${userId}`)
   const userData = await userResponse.json()
   const user = userData?.data ?? null
 

--- a/src/routes/profile/[user_id]/+page.server.js
+++ b/src/routes/profile/[user_id]/+page.server.js
@@ -1,0 +1,29 @@
+// Use SvelteKit helpers to redirect unauthenticated users and throw HTTP errors.
+import { redirect, error } from '@sveltejs/kit'
+
+// Runs on the server before rendering this dynamic profile page.
+export async function load({ fetch, params, locals }) {
+  // Read the logged-in user from the request locals.
+  const sessionUser = locals.user
+
+  // Protect this page: if there is no logged-in email, send user to login.
+  if (!sessionUser?.email) {
+    throw redirect(302, '/login')
+  }
+
+  // Grab the dynamic route param.
+  const userId = params.user_id
+  // Request the profile record for the requested user id from Directus.
+  const userResponse = await fetch(
+    'https://fdnd-agency.directus.app/items/footguard_users/' + userId
+  )
+  const userData = await userResponse.json()
+  const user = userData?.data ?? null
+
+  // If no user was returned, show a 404 page.
+  if (!user) {
+    throw error(404, 'User not found')
+  }
+
+  return { user }
+}

--- a/src/routes/profile/[user_id]/+page.server.js
+++ b/src/routes/profile/[user_id]/+page.server.js
@@ -1,16 +1,7 @@
-// Use SvelteKit helpers to redirect unauthenticated users and throw HTTP errors.
-import { redirect, error } from '@sveltejs/kit'
+import { error } from '@sveltejs/kit'
 
 // Runs on the server before rendering this dynamic profile page.
-export async function load({ fetch, params, locals }) {
-  // Read the logged-in user from the request locals.
-  const sessionUser = locals.user
-
-  // Protect this page: if there is no logged-in email, send user to login.
-  if (!sessionUser?.email) {
-    throw redirect(302, '/login')
-  }
-
+export async function load({ fetch, params }) {
   // Grab the dynamic route param.
   const userId = params.user_id
   // Request the profile record for the requested user id from Directus.


### PR DESCRIPTION
## What does this change?

Resolves issue #310

Adds a Guidelines filter on the Groups page using a native `select` with URL query updates.

- Added 3 options: `Guidelines` (placeholder), `Guidelines 2023`, `Guidelines 2027`
- Auto-submit on change with GET (`?year=...`)
- Styled `select`/options to match UI
- Selected option is highlighted in green
- Default checkmark in options is hidden

## How Has This Been Tested?

- [x] [Responsive Design test]()
- [x] [Accessibility test]()
- [x] [Device test]()

## Images

Before: no Guidelines filter.  
<img width="855" height="808" alt="image" src="https://github.com/user-attachments/assets/7e6609b0-49e9-4176-958f-905928ed12cf" />

After: selecting a guideline updates URL and shows styled selected state.
<img width="930" height="911" alt="image" src="https://github.com/user-attachments/assets/867b84ab-53f1-4bd1-a5c8-cf3d7a92ac16" />
<img width="781" height="913" alt="image" src="https://github.com/user-attachments/assets/ed263998-3af1-40cb-b6a0-acd039d1c76b" />
<img width="454" height="335" alt="image" src="https://github.com/user-attachments/assets/3952375e-4b79-471f-af3a-23a74c1e124b" />


## How to review

1. Open Groups page
2. Select `Guidelines 2023` or `Guidelines 2027`
3. Confirm URL updates with `?year=...`
4. Confirm selected option is green and has no checkmark