### PR TITLE
312 feat/dynamic profile pages for each user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DIRECTUS_TOKEN=
+PUBLIC_DIRECTUS_URL=https://fdnd-agency.directus.app
 PUBLIC_APP_URL=https://footguard.dev.fdnd.nl
 EMAIL_PROVIDER=resend
 MAIL_FROM=no-reply@fdnd.nl

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -102,6 +102,7 @@
   /* Typography */
   --main-font: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
 
+  
   /* Primary blue colors */
   --blue-700: hsl(203, 90%, 22%);
   --blue-600: hsl(203, 85%, 32%);
@@ -186,6 +187,9 @@
   --transition-fast: 0.15s ease;
   --transition-base: 0.2s ease;
   --transition-slow: 0.3s ease;
+
+    /* Form input size for mobile devices */
+    --form-mobile-input-size: 16px;
 }
 
 html {
@@ -273,6 +277,7 @@ input,
 textarea,
 select {
   font-family: inherit;
+  font-size: var(--form-mobile-input-size);
 }
 
 .skip-link {

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -102,7 +102,6 @@
   /* Typography */
   --main-font: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
 
-  
   /* Primary blue colors */
   --blue-700: hsl(203, 90%, 22%);
   --blue-600: hsl(203, 85%, 32%);
@@ -188,8 +187,8 @@
   --transition-base: 0.2s ease;
   --transition-slow: 0.3s ease;
 
-    /* Form input size for mobile devices */
-    --form-mobile-input-size: 16px;
+  /* Form input size for mobile devices */
+  --form-mobile-input-size: 16px;
 }
 
 html {

--- a/src/routes/profile/+layout.server.js
+++ b/src/routes/profile/+layout.server.js
@@ -1,0 +1,8 @@
+import { redirect } from '@sveltejs/kit'
+
+// Redirect to login if not authenticated; applies to all /profile/* routes.
+export function load({ locals }) {
+  const user = locals.user
+  if (!user) throw redirect(302, '/login')
+  return { user }
+}

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -1,10 +1,10 @@
 export async function load({ fetch, locals }) {
   const sessionUser = locals.user
 
-  // Fetch users from Directus filtered by the logged-in user's email.
+  // Fetch user from Directus by exact email match.
   const usersResponse = await fetch(
     'https://fdnd-agency.directus.app/items/footguard_users?' +
-      `filter[email][_icontains]=${encodeURIComponent(sessionUser.email)}&limit=1`
+      `filter[email][_eq]=${encodeURIComponent(sessionUser.email)}&limit=1`
   )
 
   if (!usersResponse.ok) {

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -1,6 +1,19 @@
-export async function load({ fetch }) {
-  const userDetailsResponse = await fetch('https://fdnd-agency.directus.app/items/footguard_users/')
-  const userDetailsData = await userDetailsResponse.json()
-  let userInfo = userDetailsData.data
-  return { userInfo }
+export async function load({ fetch, locals }) {
+  const sessionUser = locals.user
+
+  // Fetch users from Directus filtered by the logged-in user's email.
+  const usersResponse = await fetch(
+    'https://fdnd-agency.directus.app/items/footguard_users?' +
+      `filter[email][_icontains]=${encodeURIComponent(sessionUser.email)}&limit=1`
+  )
+
+  if (!usersResponse.ok) {
+    return { user: sessionUser }
+  }
+
+  // Parse the Directus response; the users array lives in the .data property.
+  const usersResult = await usersResponse.json()
+  const [user] = usersResult?.data ?? []
+
+  return { user: user ?? sessionUser }
 }

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -1,9 +1,13 @@
+import { env } from '$env/dynamic/public'
+
+const DIRECTUS_URL = env.PUBLIC_DIRECTUS_URL || 'https://fdnd-agency.directus.app'
+
 export async function load({ fetch, locals }) {
   const sessionUser = locals.user
 
   // Fetch user from Directus by exact email match.
   const usersResponse = await fetch(
-    'https://fdnd-agency.directus.app/items/footguard_users?' +
+    `${DIRECTUS_URL}/items/footguard_users?` +
       `filter[email][_eq]=${encodeURIComponent(sessionUser.email)}&limit=1`
   )
 

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -4,7 +4,7 @@
   import ProfileHero from "$lib/components/profile/ProfileHero.svelte";
   import ProfileInfo from "$lib/components/profile/ProfileInfo.svelte";
   let { data } = $props();
-  const user = data.userInfo?.[0];
+  const user = $derived(data.user);
 </script>
 
 

--- a/src/routes/profile/[user_id]/+page.server.js
+++ b/src/routes/profile/[user_id]/+page.server.js
@@ -1,13 +1,14 @@
 import { error } from '@sveltejs/kit'
+import { env } from '$env/dynamic/public'
+
+const DIRECTUS_URL = env.PUBLIC_DIRECTUS_URL || 'https://fdnd-agency.directus.app'
 
 // Runs on the server before rendering this dynamic profile page.
 export async function load({ fetch, params }) {
   // Grab the dynamic route param.
   const userId = params.user_id
   // Request the profile record for the requested user id from Directus.
-  const userResponse = await fetch(
-    'https://fdnd-agency.directus.app/items/footguard_users/' + userId
-  )
+  const userResponse = await fetch(`${DIRECTUS_URL}/items/footguard_users/${userId}`)
   const userData = await userResponse.json()
   const user = userData?.data ?? null
 

--- a/src/routes/profile/[user_id]/+page.server.js
+++ b/src/routes/profile/[user_id]/+page.server.js
@@ -1,0 +1,29 @@
+// Use SvelteKit helpers to redirect unauthenticated users and throw HTTP errors.
+import { redirect, error } from '@sveltejs/kit'
+
+// Runs on the server before rendering this dynamic profile page.
+export async function load({ fetch, params, locals }) {
+  // Read the logged-in user from the request locals.
+  const sessionUser = locals.user
+
+  // Protect this page: if there is no logged-in email, send user to login.
+  if (!sessionUser?.email) {
+    throw redirect(302, '/login')
+  }
+
+  // Grab the dynamic route param.
+  const userId = params.user_id
+  // Request the profile record for the requested user id from Directus.
+  const userResponse = await fetch(
+    'https://fdnd-agency.directus.app/items/footguard_users/' + userId
+  )
+  const userData = await userResponse.json()
+  const user = userData?.data ?? null
+
+  // If no user was returned, show a 404 page.
+  if (!user) {
+    throw error(404, 'User not found')
+  }
+
+  return { user }
+}

--- a/src/routes/profile/[user_id]/+page.server.js
+++ b/src/routes/profile/[user_id]/+page.server.js
@@ -1,16 +1,7 @@
-// Use SvelteKit helpers to redirect unauthenticated users and throw HTTP errors.
-import { redirect, error } from '@sveltejs/kit'
+import { error } from '@sveltejs/kit'
 
 // Runs on the server before rendering this dynamic profile page.
-export async function load({ fetch, params, locals }) {
-  // Read the logged-in user from the request locals.
-  const sessionUser = locals.user
-
-  // Protect this page: if there is no logged-in email, send user to login.
-  if (!sessionUser?.email) {
-    throw redirect(302, '/login')
-  }
-
+export async function load({ fetch, params }) {
   // Grab the dynamic route param.
   const userId = params.user_id
   // Request the profile record for the requested user id from Directus.


### PR DESCRIPTION
## What does this change?

Resolves issue #312 

Implements authenticated profile pages that dynamically load user data from the Directus API. 
Users can now view their own profile with data pulled directly from the backend.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()


## Images
<img width="342" height="686" alt="Screenshot 2026-03-19 at 15 10 27" src="https://github.com/user-attachments/assets/a5c0d5ac-64df-4483-a422-84c8cf03f3c3" />
<img width="342" height="686" alt="Screenshot 2026-03-19 at 15 11 08" src="https://github.com/user-attachments/assets/08dec397-2731-4372-bee1-41e2225aab9a" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
**Befor it was only loading on first user everytime** 

## How to review

On this branch, navigate to `/profile` and verify:
* Page is protected — unauthenticated users redirect to `/login`
* Your profile loads with data from Directus (not hardcoded)
* User data is fetched by email 

