### PR TITLE
305 feature add guest role to read articles login required

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -14,6 +14,7 @@ type SessionCookie = {
 
 export const handle: Handle = async ({ event, resolve }) => {
   const raw = event.cookies.get(SESSION_COOKIE)
+
   if (raw) {
     try {
       const session = JSON.parse(raw) as SessionCookie
@@ -59,34 +60,37 @@ export const handle: Handle = async ({ event, resolve }) => {
       event.cookies.delete(SESSION_COOKIE, { path: '/' })
     }
   }
-  const protectedPaths = ['/dashboard', '/assessment', '/admin']
-  const isProtected = protectedPaths.some((p) => event.url.pathname.startsWith(p))
-
-  if (isProtected && !event.locals.user) {
-    throw redirect(302, '/login')
-  }
-
-  // Role-based access control
-  const adminOnlyPaths = ['/admin']
-  const assessorPaths = ['/research', '/results']
-
   const path = event.url.pathname
 
+  const protectedPaths = [
+    '/dashboard',
+    '/assessment',
+    '/admin',
+    '/research',
+    '/results',
+    '/profile',
+    '/notifications',
+    '/settings',
+    '/grading'
+  ]
+
   // not logged in -> redirect to login
-  if (!event.locals.user) {
-    const protectedPaths = ['/admin', '/research', '/results', '/profile', '/notifications']
-    if (protectedPaths.some((p) => path.startsWith(p))) {
-      throw redirect(302, '/login')
-    }
-  }
-
-  // Logged in but wrong role
   if (event.locals.user) {
-    const role = event.locals.user.role
+    const role = event.locals.user.role.toLowerCase()
 
-    //Only super_admin and admin can access /admin
+    // Alleen super_admin en admin kunnen naar /admin
     if (path.startsWith('/admin') && role !== 'super_admin' && role !== 'admin') {
       throw redirect(302, '/')
+    }
+
+    // Guest mag ALLEEN naar /research
+    if (role === 'guest') {
+      const guestAllowed = ['/research', '/login', '/logout', '/']
+      const isAllowed = guestAllowed.some((p) => (path === '/' ? path === p : path.startsWith(p)))
+
+      if (!isAllowed) {
+        throw redirect(302, '/research')
+      }
     }
   }
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -63,18 +63,9 @@ export const handle: Handle = async ({ event, resolve }) => {
   const path = event.url.pathname
 
   if (!event.locals.user) {
-    const protectedPaths = [
-      '/dashboard',
-      '/assessment',
-      '/admin',
-      '/research',
-      '/results',
-      '/profile',
-      '/notifications',
-      '/settings',
-      '/grading'
-    ]
-    if (protectedPaths.some((p) => path.startsWith(p))) {
+    const publicPaths = ['/login']
+    const isPublic = publicPaths.some((p) => path === p || path.startsWith(p + '/'))
+    if (!isPublic) {
       throw redirect(302, '/login')
     }
   }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -62,17 +62,22 @@ export const handle: Handle = async ({ event, resolve }) => {
   }
   const path = event.url.pathname
 
-  const protectedPaths = [
-    '/dashboard',
-    '/assessment',
-    '/admin',
-    '/research',
-    '/results',
-    '/profile',
-    '/notifications',
-    '/settings',
-    '/grading'
-  ]
+  if (!event.locals.user) {
+    const protectedPaths = [
+      '/dashboard',
+      '/assessment',
+      '/admin',
+      '/research',
+      '/results',
+      '/profile',
+      '/notifications',
+      '/settings',
+      '/grading'
+    ]
+    if (protectedPaths.some((p) => path.startsWith(p))) {
+      throw redirect(302, '/login')
+    }
+  }
 
   // not logged in -> redirect to login
   if (event.locals.user) {

--- a/src/lib/components/layout/Navbar.svelte
+++ b/src/lib/components/layout/Navbar.svelte
@@ -1,90 +1,98 @@
 <script>
-	import {
-		AdminIcon,
-		CollapseMenuIcon,
-		DashboardIcon,
-		GradingIcon,
-		NotificationIcon,
-		ProfileIcon,
-		ResultsIcon,
-		SettingIcon,
-		IwgdfLogo,
-		IwgdfLogoCollapsed
-	} from "$lib";
+  import {
+    AdminIcon,
+    CollapseMenuIcon,
+    DashboardIcon,
+    GradingIcon,
+    NotificationIcon,
+    ProfileIcon,
+    ResultsIcon,
+    SettingIcon,
+    IwgdfLogo,
+    IwgdfLogoCollapsed
+  } from "$lib";
+  import { resolve } from "$app/paths";
+  import { isCollapsed } from "$lib/stores/sidebar.js";
 
-	import { resolve } from "$app/paths";
+  let { user } = $props()
+  const isGuest = user?.role?.toLowerCase() === 'guest'
 
-
-	import { isCollapsed } from "$lib/stores/sidebar.js";
-
-	const toggleCollapse = () => {
-		isCollapsed.update((value) => !value);
-	};
+  const toggleCollapse = () => {
+    isCollapsed.update((value) => !value);
+  };
 </script>
 
 <nav class:collapsed={$isCollapsed}>
-	<div class="logo">
-		{#if $isCollapsed}
-			<IwgdfLogoCollapsed />
-		{:else}
-			<IwgdfLogo />
-		{/if}
+  <div class="logo">
+    {#if $isCollapsed}
+      <IwgdfLogoCollapsed />
+    {:else}
+      <IwgdfLogo />
+    {/if}
+    <button
+      type="button"
+      class="collapse-btn"
+      onclick={toggleCollapse}
+      aria-label="Toggle sidebar"
+      aria-expanded={!$isCollapsed}
+    >
+      <CollapseMenuIcon />
+    </button>
+  </div>
 
-		<button
-			type="button"
-			class="collapse-btn"
-			on:click={toggleCollapse}
-			aria-label="Toggle sidebar"
-			aria-expanded={!$isCollapsed}
-		>
-			<CollapseMenuIcon />
-		</button>
-	</div>
-
-	<ul>
-		<li>
-			<a href={resolve("/")}>
-				<span class="icon"><DashboardIcon /></span>
-				<span class="label">Dashboard</span>
-			</a>
-		</li>
-		<li>
-			<a href={resolve("/profile")}>
-				<span class="icon"><ProfileIcon /></span>
-				<span class="label">Profile</span>
-			</a>
-		</li>
-		<li>
-			<a href={resolve("/research")}>
-				<span class="icon"><GradingIcon /></span>
-				<span class="label">Grading</span>
-			</a>
-		</li>
-		<li>
-			<a href={resolve("/results")}>
-				<span class="icon"><ResultsIcon /></span>
-				<span class="label">Results</span>
-			</a>
-		</li>
-		<li class="admin-item">
-			<a href={resolve("/admin")}>
-				<span class="icon"><AdminIcon /></span>
-				<span class="label">Admin</span>
-			</a>
-		</li>
-		<li>
-			<a href={resolve("/notifications")}>
-				<span class="icon"><NotificationIcon /></span>
-				<span class="label">Notifications</span>
-			</a>
-		</li>
-		<li>
-			<a href={resolve("/settings")}>
-				<span class="icon"><SettingIcon /></span>
-				<span class="label">Settings</span>
-			</a>
-		</li>
-	</ul>
+  <ul>
+    {#if isGuest}
+      <li>
+         <a href={resolve("/research")}>
+      <span class="icon"><GradingIcon /></span>
+      <span class="label">Grading</span>
+        </a>
+      </li>
+    {:else}
+      <li>
+        <a href={resolve("/")}>
+          <span class="icon"><DashboardIcon /></span>
+          <span class="label">Dashboard</span>
+        </a>
+      </li>
+      <li>
+        <a href={resolve("/profile")}>
+          <span class="icon"><ProfileIcon /></span>
+          <span class="label">Profile</span>
+        </a>
+      </li>
+      <li>
+        <a href={resolve("/research")}>
+          <span class="icon"><GradingIcon /></span>
+          <span class="label">Grading</span>
+        </a>
+      </li>
+      <li>
+        <a href={resolve("/results")}>
+          <span class="icon"><ResultsIcon /></span>
+          <span class="label">Results</span>
+        </a>
+      </li>
+      <li class="admin-item">
+        <a href={resolve("/admin")}>
+          <span class="icon"><AdminIcon /></span>
+          <span class="label">Admin</span>
+        </a>
+      </li>
+      <li>
+        <a href={resolve("/notifications")}>
+          <span class="icon"><NotificationIcon /></span>
+          <span class="label">Notifications</span>
+        </a>
+      </li>
+      <li>
+        <a href={resolve("/settings")}>
+          <span class="icon"><SettingIcon /></span>
+          <span class="label">Settings</span>
+        </a>
+      </li>
+    {/if}
+  </ul>
 </nav>
 
 

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -1,5 +1,17 @@
-export function load({ locals }) {
-  return {
-    user: locals.user ?? null
+import { redirect } from '@sveltejs/kit'
+
+export function load({ locals, url }) {
+  const user = locals.user ?? null
+  const path = url.pathname
+  const role = user?.role?.toLowerCase() ?? null
+
+  // Guest mag alleen /research
+  if (role === 'guest') {
+    const guestAllowed = ['/research', '/login', '/logout']
+    if (!guestAllowed.some((p) => path.startsWith(p))) {
+      throw redirect(302, '/research')
+    }
   }
+
+  return { user }
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
   import { onMount } from "svelte";
   import { page } from '$app/stores';
 
-  let { children } = $props();
+  let { children, data } = $props();
 
   let isMobile = $state(false);
 
@@ -35,9 +35,11 @@
 <div class="app-layout">
   {#if $page.url.pathname !== '/login'}
   {#if isMobile}
-    <MobileNav />
-  {:else}
-    <Navbar />
+    <!-- user doorgeven -->
+      <MobileNav user={data.user} />
+    {:else}
+      <!-- user doorgeven -->
+      <Navbar user={data.user} />
   {/if}
   {/if}
 

--- a/src/routes/login/magic-login/+server.js
+++ b/src/routes/login/magic-login/+server.js
@@ -80,7 +80,6 @@ export async function GET({ url, cookies }) {
   const rawRole = Array.isArray(user.role) ? user.role[0] : user.role
   const role = rawRole == null ? '' : String(rawRole).toLowerCase()
 
-
   // 5) Session
   const sessionUser = {
     id: String(user.id),

--- a/src/routes/login/magic-login/+server.js
+++ b/src/routes/login/magic-login/+server.js
@@ -21,7 +21,6 @@ export async function GET({ url, cookies }) {
   )
 
   const data = await response.json()
-  console.log('MAGIC LOGIN directus status:', response.status, data?.data?.length)
 
   if (!response.ok) {
     console.error('MAGIC LOGIN: magic link lookup failed', data)
@@ -78,10 +77,15 @@ export async function GET({ url, cookies }) {
   const user = userData.data[0]
 
   // 5) Session (force simple types!)
+  const rawRole = Array.isArray(user.role) ? user.role[0] : user.role
+  const role = rawRole == null ? '' : String(rawRole).toLowerCase()
+
+
+  // 5) Session
   const sessionUser = {
     id: String(user.id),
     email: String(user.email),
-    role: user.role == null ? '' : String(user.role),
+    role: role,
     workgroup: user.workgroup == null ? null : String(user.workgroup),
     lastSeen: Date.now()
   }
@@ -94,5 +98,9 @@ export async function GET({ url, cookies }) {
     maxAge: 60 * 60
   })
 
-  throw redirect(302, '/')
+  // 6) Redirect based on role
+  if (sessionUser.role === 'guest') {
+    throw redirect(302, '/research')
+  }
+  throw redirect(302, '/dashboard')
 }


### PR DESCRIPTION
## What does this change?

Resolves issue #305 

This PR adds a new guest role to the application. Guest users can log in via the existing magic link system and read articles on the /research section. They cannot access /admin, assessment-related pages, or any other restricted routes.

Changes made:

- hooks.server.ts — consolidated all protected paths into one central list, added guest role check that restricts access to /research only, changed unauthenticated protection to allowlist approach (only /login is public, everything else redirects to /login)
- login/magic-login/+server.js — fixed Directus returning role as array ['Guest'] instead of string, added .toLowerCase() normalization, redirect guest to /research after login instead of /dashboard
- +layout.server.js — added guest role check
- +layout.svelte — pass user prop to Navbar and MobileNav
- Navbar.svelte — guests only see the Grading (/research) link, all other nav items are hidden.
- +error.svelte — improved error page with dynamic status code and guest-aware back link.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images

<img width="1213" height="765" alt="Screenshot 2026-03-31 at 10 59 38" src="https://github.com/user-attachments/assets/8215ff4f-cc98-4a5a-ab5b-ec60dbf22b86" />

<img width="1209" height="761" alt="Screenshot 2026-03-31 at 11 01 13" src="https://github.com/user-attachments/assets/24426837-2283-4053-a1a6-291d46e4c088" />

Guest navbarOnly -  shows Grading link

## How to review

1. Log in as a guest user via magic link with a guest email
2. Verify you land on /research after login
3. Try navigating to /dashboard, /profile, /admin, /notifications — you should always be redirected back to /research
4. Verify the navbar only shows the Grading link for guests
5. Log out and type localhost:5173/dev or any random URL — you should be redirected to /login
6. Log in as admin or assessor and verify all pages still work normally
