### PR TITLE
feat: add EditActions component for profile edit/save/cancel #318

### DIFF
--- a/src/lib/components/profile/EditActions.svelte
+++ b/src/lib/components/profile/EditActions.svelte
@@ -1,0 +1,87 @@
+<script>
+  let { isEditing = false, disabled = false, onStartEdit, onSave, onCancel } = $props();
+</script>
+
+<div class="top-actions">
+  {#if !isEditing}
+    <button class="btn btn-edit" type="button" onclick={onStartEdit} {disabled}>
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+      </svg>
+      Edit Profile
+    </button>
+  {:else}
+    <button class="btn btn-cancel" type="button" onclick={onCancel} {disabled}>Cancel</button>
+    <button class="btn btn-save" type="button" onclick={onSave} {disabled}>
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+        <polyline points="20 6 9 17 4 12" />
+      </svg>
+      Save Changes
+    </button>
+  {/if}
+</div>
+
+<style>
+  .top-actions {
+    position: absolute;
+    top: var(--spacing-sm);
+    right: var(--spacing-md);
+    display: flex;
+    gap: var(--spacing-xs);
+    z-index: 2;
+
+    .btn {
+      border: none;
+      border-radius: var(--radius-sm);
+      padding: var(--spacing-xs) var(--spacing-md);
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: var(--spacing-xs);
+      transition: background var(--transition-base);
+
+      &:disabled {
+        opacity: 0.75;
+        cursor: not-allowed;
+      }
+
+      &:focus-visible {
+        outline: 3px solid var(--blue-100);
+        outline-offset: 2px;
+      }
+    }
+
+    .btn-edit {
+      background: rgb(255 255 255 / 25%);
+      color: var(--background-color-primary);
+
+      &:hover:not(:disabled) {
+        background: rgb(255 255 255 / 40%);
+      }
+    }
+
+    .btn-save {
+      background: var(--background-color-primary);
+      color: var(--blue-500);
+      font-weight: 700;
+      box-shadow: var(--shadow-sm);
+
+      &:hover:not(:disabled) {
+        background: var(--blue-100);
+      }
+    }
+
+    .btn-cancel {
+      background: rgb(255 255 255 / 15%);
+      border: 1.5px solid rgb(255 255 255 / 50%);
+      color: var(--background-color-primary);
+
+      &:hover:not(:disabled) {
+        background: rgb(255 255 255 / 28%);
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
## What does this change?

Resolves #318 

The profile page previously had no edit handling actions logic. This PR introduces `EditActions.svelte`, a focused UI component that manages the Edit / Save / Cancel button on the profile header.

**Component API:**
- `isEditing` (boolean, default `false`) — controls which button state is rendered
- `disabled` (boolean, default `false`) — disables all buttons, e.g. during async save
- `onStartEdit`, `onSave`, `onCancel` — callback props for parent-controlled state

**Behaviour:**
- When `isEditing` is `false`: renders a single **Edit Profile** button with a pencil icon
- When `isEditing` is `true`: renders **Cancel** + **Save Changes** (with checkmark icon)
- Buttons are absolutely positioned top-right of the profile header using design tokens
- All interactive states covered: hover, disabled (opacity + cursor), and focus-visible (outline for keyboard nav)

## How Has This Been Tested?

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images
### Befor:
<img width="1046" height="617" alt="Screenshot 2026-03-05 at 22 33 35" src="https://github.com/user-attachments/assets/0200a253-161a-4be8-8e07-405f7b4d7bad" />

### After:

<img width="1263" height="734" alt="Screenshot 2026-03-31 at 16 36 59" src="https://github.com/user-attachments/assets/807a1947-37b4-43d2-88c6-f87f4097457a" />
<img width="935" height="221" alt="Screenshot 2026-03-31 at 16 39 39" src="https://github.com/user-attachments/assets/4f4b349b-a195-492e-bf1a-e8de147aeb2c" />



## How to review

1. Check out this branch and navigate to the profile page
2. Confirm the **Edit Profile** button renders top-right of the profile header
3. Click **Edit Profile** → should switch to **Cancel** + **Save Changes**
4. Click **Cancel** → should return to the Edit Profile button without saving
5. Tab through the buttons and confirm focus rings appear correctly