### PR TITLE
add id to session token for a personalized dashboard

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -2,6 +2,7 @@ declare global {
   namespace App {
     interface Locals {
       user?: {
+        id: string
         email: string
         role: string
         workgroup: string | null

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -6,6 +6,7 @@ const SESSION_COOKIE = 'session'
 const INACTIVITY_LIMIT_MS = 60 * 60 * 1000 // 1 hour
 
 type SessionCookie = {
+  id: string
   email: string
   role: string
   workgroup: string | null
@@ -19,6 +20,7 @@ export const handle: Handle = async ({ event, resolve }) => {
       const session = JSON.parse(raw) as SessionCookie
 
       const hasRequired =
+        typeof session.id === 'string' &&
         typeof session.email === 'string' &&
         typeof session.role === 'string' &&
         typeof session.lastSeen === 'number' &&
@@ -37,6 +39,7 @@ export const handle: Handle = async ({ event, resolve }) => {
         } else {
           // Set locals.user
           event.locals.user = {
+            id: session.id,
             email: session.email,
             role: session.role,
             workgroup: session.workgroup

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -8,9 +8,14 @@ export async function load({ fetch, locals }) {
   if (!locals.user) {
     throw redirect(302, '/login')
   }
+
+  const currentUserId = locals.user.id
   try {
-    const usersRes = await fetch(`${BASE_URL}/items/footguard_users`)
+    const usersRes = await fetch(
+      `${BASE_URL}/items/footguard_users?filter[id][_eq]=${encodeURIComponent(currentUserId)}&limit=1`
+    )
     const usersData = await usersRes.json()
+
     const users = usersData.data || []
 
     const currentUser = users[0] || { name: 'Guest', id: null }


### PR DESCRIPTION
This pull request enhances user session handling and improves how the current user is fetched on the server side. The main changes add a user `id` to the session and ensure that user-specific data is retrieved more securely and efficiently.

**Session management improvements:**

* Added an `id` field to the `SessionCookie` type and included it in the session validation logic in `src/hooks.server.ts`. This makes sure every session has a unique user identifier and that it's validated on each request. [[1]](diffhunk://#diff-b5aa13ce0a61c3f166000471d0729aa6a8e57292fdbd8d88452443502e4b9a4aR9) [[2]](diffhunk://#diff-b5aa13ce0a61c3f166000471d0729aa6a8e57292fdbd8d88452443502e4b9a4aR23)
* Updated the assignment of `event.locals.user` to include the `id` property, making the user identifier available throughout the request lifecycle.

**User data fetching improvements:**

* Modified the user loading logic in `src/routes/+page.server.js` to fetch only the current user's data by filtering the API request with the user's `id`, instead of retrieving all users. This improves efficiency and security by limiting the data returned to only the logged-in user.## What does this change?

Resolves issue #1337

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

