### PR TITLE
259 feat/profile page edit

### DIFF
--- a/src/lib/components/profile/EditActions.svelte
+++ b/src/lib/components/profile/EditActions.svelte
@@ -1,0 +1,87 @@
+<script>
+  let { isEditing = false, disabled = false, onStartEdit, onSave, onCancel } = $props();
+</script>
+
+<div class="top-actions">
+  {#if !isEditing}
+    <button class="btn btn-edit" type="button" onclick={onStartEdit} {disabled}>
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+      </svg>
+      Edit Profile
+    </button>
+  {:else}
+    <button class="btn btn-cancel" type="button" onclick={onCancel} {disabled}>Cancel</button>
+    <button class="btn btn-save" type="button" onclick={onSave} {disabled}>
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+        <polyline points="20 6 9 17 4 12" />
+      </svg>
+      Save Changes
+    </button>
+  {/if}
+</div>
+
+<style>
+  .top-actions {
+    position: absolute;
+    top: var(--spacing-sm);
+    right: var(--spacing-md);
+    display: flex;
+    gap: var(--spacing-xs);
+    z-index: 2;
+
+    .btn {
+      border: none;
+      border-radius: var(--radius-sm);
+      padding: var(--spacing-xs) var(--spacing-md);
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: var(--spacing-xs);
+      transition: background var(--transition-base);
+
+      &:disabled {
+        opacity: 0.75;
+        cursor: not-allowed;
+      }
+
+      &:focus-visible {
+        outline: 3px solid var(--blue-100);
+        outline-offset: 2px;
+      }
+    }
+
+    .btn-edit {
+      background: rgb(255 255 255 / 25%);
+      color: var(--background-color-primary);
+
+      &:hover:not(:disabled) {
+        background: rgb(255 255 255 / 40%);
+      }
+    }
+
+    .btn-save {
+      background: var(--background-color-primary);
+      color: var(--blue-500);
+      font-weight: 700;
+      box-shadow: var(--shadow-sm);
+
+      &:hover:not(:disabled) {
+        background: var(--blue-100);
+      }
+    }
+
+    .btn-cancel {
+      background: rgb(255 255 255 / 15%);
+      border: 1.5px solid rgb(255 255 255 / 50%);
+      color: var(--background-color-primary);
+
+      &:hover:not(:disabled) {
+        background: rgb(255 255 255 / 28%);
+      }
+    }
+  }
+</style>

--- a/src/lib/components/profile/ProfileHero.svelte
+++ b/src/lib/components/profile/ProfileHero.svelte
@@ -1,17 +1,70 @@
 <script>
-  let { user } = $props();
-  const profileName = user?.name ?? "Unknown user";
-  const profession = user?.profession ?? "Unknown profession";
-  const avatarSrc = user?.photo
-    ? `https://fdnd-agency.directus.app/assets/${user.photo}`
-    : "https://placehold.co/112x112";
+  let { user, isEditing = false, formData, onFieldChange, avatarId, onAvatarUpload } = $props();
+
+  // Show live edited values, and fallback to saved user data when needed.
+  const profileName = $derived(formData?.name ?? user?.name ?? 'Unknown user');
+  const profession = $derived(formData?.profession ?? user?.profession ?? 'Unknown profession');
+
+  // Build avatar URL from uploaded preview id or existing user photo id.
+  const avatarSrc = $derived(
+    (avatarId ?? user?.photo)
+      ? `https://fdnd-agency.directus.app/assets/${avatarId ?? user?.photo}`
+      : 'https://placehold.co/112x112'
+  );
+
+  // Reference to hidden file input used by "Change photo" button.
+  let fileInput = $state();
+
+  // Open the hidden file input when "Change photo" is clicked.
+  function openFilePicker() {
+    fileInput?.click();
+  }
+
+  // Read selected image file and pass it up to parent upload handler.
+  function handleFileChange(event) {
+    const file = event.currentTarget.files?.[0];
+    if (file) onAvatarUpload?.(file);
+    // Clear input so selecting the same file again still triggers change.
+    event.currentTarget.value = '';
+  }
 </script>
 
 <section class="profile-hero">
-  <img class="profile-avatar" src={avatarSrc} alt={`Avatar of ${profileName}`} />
+  <div class="avatar-wrap">
+    <img class="profile-avatar" src={avatarSrc} alt={`Avatar of ${profileName}`} />
+    {#if isEditing}
+      <button class="avatar-upload" type="button" onclick={openFilePicker}>Change photo</button>
+      <input
+        bind:this={fileInput}
+        class="avatar-input"
+        type="file"
+        accept="image/*"
+        onchange={handleFileChange}
+      />
+    {/if}
+  </div>
   <div class="profile-info">
-    <h2>{profileName}</h2>
-    <p>{profession}</p>
+    {#if isEditing}
+      <label class="sr-only" for="profile-name-input">Name</label>
+      <input
+        id="profile-name-input"
+        class="name-input"
+        type="text"
+        value={formData?.name ?? ''}
+        oninput={(event) => onFieldChange?.('name', event.currentTarget.value)}
+      />
+      <label class="sr-only" for="profile-profession-input">Profession</label>
+      <input
+        id="profile-profession-input"
+        class="profession-input"
+        type="text"
+        value={formData?.profession ?? ''}
+        oninput={(event) => onFieldChange?.('profession', event.currentTarget.value)}
+      />
+    {:else}
+      <h2>{profileName}</h2>
+      <p>{profession}</p>
+    {/if}
   </div>
 </section>
 
@@ -31,20 +84,53 @@
       grid-row: 1;
     }
 
-    .profile-avatar {
-      width: 6rem;
-      height: 6rem;
-      border-radius: var(--radius-full);
-      border: 3px solid var(--background-color-primary);
-      background: linear-gradient(145deg, var(--green-200), var(--blue-300));
-      color: var(--background-color-primary);
-      display: grid;
-      place-items: center;
-      box-shadow: var(--shadow-sm);
+    .avatar-wrap {
       grid-column: 1;
       grid-row: 1;
       align-self: end;
       transform: translateY(50%);
+      position: relative;
+
+      .profile-avatar {
+        width: 6rem;
+        height: 6rem;
+        border-radius: var(--radius-full);
+        border: 3px solid var(--background-color-primary);
+        background: linear-gradient(145deg, var(--green-200), var(--blue-300));
+        color: var(--background-color-primary);
+        display: grid;
+        place-items: center;
+        box-shadow: var(--shadow-sm);
+      }
+
+      .avatar-upload {
+        position: absolute;
+        inset: auto 0 0 0;
+        margin: 0 auto;
+        transform: translateY(10%);
+        width: max-content;
+        border: none;
+        border-radius: var(--radius-full);
+        background: var(--blue-700);
+        color: var(--background-color-primary);
+        font-size: 0.875rem;
+        padding: var(--spacing-xs) var(--spacing-sm);
+        cursor: pointer;
+
+        &:hover {
+          background: var(--blue-700);
+        }
+
+        &:focus-visible {
+          outline: 3px solid var(--blue-100);
+          outline-offset: 2px;
+        }
+      }
+
+      .avatar-input {
+        display: none;
+      }
+
     }
 
     .profile-info {
@@ -60,6 +146,27 @@
         margin-top: 0.3rem;
         color: var(--grey-400);
       }
+
+      .name-input,
+      .profession-input {
+        width: min(16rem, 90vw);
+        margin: 0 auto;
+        border: 2px solid var(--blue-500);
+        border-radius: var(--radius-sm);
+        padding: var(--spacing-xs) var(--spacing-sm);
+        background: var(--blue-100);
+        text-align: center;
+      }
+
+      .name-input {
+        font-weight: 700;
+        color: var(--blue-700);
+      }
+
+      .profession-input {
+        margin-top: var(--spacing-xs);
+        color: var(--grey-500);
+      }
     }
   }
 
@@ -72,9 +179,11 @@
         border-radius: 0;
       }
 
-      .profile-avatar {
-        width: 7rem;
-        height: 7rem;
+      .avatar-wrap {
+        .profile-avatar {
+          width: 7rem;
+          height: 7rem;
+        }
       }
 
       .profile-info {

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -1,30 +1,49 @@
 <script>
-  let { user } = $props();
-  const roleText = $derived(
-    Array.isArray(user?.role) ? user.role.join(", ") : (user?.role ?? "Unknown")
-  );
+  let { isEditing = false, formData, onFieldChange } = $props();
 </script>
 
 <section>
   <h2>General Information</h2>
-  
 
   <form class="info-grid" aria-label="Profile details">
     <label for="info-role">
       <span>Role</span>
-      <input id="info-role" type="text" readonly value={roleText} />
+      <input
+        id="info-role"
+        type="text"
+        readonly
+        value={formData?.role ?? ''}
+      />
     </label>
     <label for="info-institution">
       <span>Institution</span>
-      <input id="info-institution" type="text" readonly value={user?.institute ?? "Unknown"} />
+      <input
+        id="info-institution"
+        type="text"
+        readonly={!isEditing}
+        value={formData?.institute ?? ''}
+        oninput={(event) => onFieldChange?.('institute', event.currentTarget.value)}
+      />
     </label>
     <label for="info-profession">
       <span>Profession</span>
-      <input id="info-profession" type="text" readonly value={user?.profession ?? "Unknown"} />
+      <input
+        id="info-profession"
+        type="text"
+        readonly={!isEditing}
+        value={formData?.profession ?? ''}
+        oninput={(event) => onFieldChange?.('profession', event.currentTarget.value)}
+      />
     </label>
     <label for="info-email">
       <span>Email</span>
-      <input id="info-email" type="text" readonly value={user?.email ?? "Unknown"} />
+      <input
+        id="info-email"
+        type="email"
+        readonly={!isEditing}
+        value={formData?.email ?? ''}
+        oninput={(event) => onFieldChange?.('email', event.currentTarget.value)}
+      />
     </label>
   </form>
 </section>
@@ -60,6 +79,15 @@
         border-radius: var(--radius-sm);
         background: var(--grey-50);
         padding: var(--spacing-sm);
+      }
+
+      input[readonly] {
+        cursor: default;
+      }
+
+      input:not([readonly]) {
+        border: 2px solid var(--blue-500);
+        background: var(--blue-100);
       }
 
       input:focus-visible {

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -316,6 +316,19 @@ select {
   transform: scale(0.98);
 }
 
+/* Utility: keep content accessible for screen readers but visually hidden. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 *:focus-visible {
   outline: 2px solid var(--blue-500);
   outline-offset: 2px;

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -1,23 +1,138 @@
 import { env } from '$env/dynamic/public'
+import { env as privateEnv } from '$env/dynamic/private'
 
+// This is my Directus base url.
 const DIRECTUS_URL = env.PUBLIC_DIRECTUS_URL || 'https://fdnd-agency.directus.app'
+// This token i use on server to update Directus data.
+const DIRECTUS_TOKEN = privateEnv.DIRECTUS_TOKEN
 
+// This load run when profile page open.
+// Here i get current user data from Directus by email,
+// so page show real latest profile info.
 export async function load({ fetch, locals }) {
   const sessionUser = locals.user
 
-  // Fetch user from Directus by exact email match.
+  // Get user by exact email from session.
   const usersResponse = await fetch(
     `${DIRECTUS_URL}/items/footguard_users?` +
       `filter[email][_eq]=${encodeURIComponent(sessionUser.email)}&limit=1`
   )
 
+  // If request fail, i fallback to session user.
   if (!usersResponse.ok) {
     return { user: sessionUser }
   }
 
-  // Parse the Directus response; the users array lives in the .data property.
+  // Directus return user list in data array.
   const usersResult = await usersResponse.json()
   const [user] = usersResult?.data ?? []
 
+  // If user found use it, else use session user.
   return { user: user ?? sessionUser }
+}
+
+// Small helper so i can PATCH user fields without repeating same code.
+const patchUser = ({ fetch, userId, payload }) =>
+  fetch(`${DIRECTUS_URL}/items/footguard_users/${userId}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${DIRECTUS_TOKEN}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  })
+
+export const actions = {
+  // This action save text fields from edit form.
+  // Called from: /profile?/saveProfile
+  saveProfile: async ({ request, fetch, locals }) => {
+    const sessionUser = locals.user
+    // Must be logged in.
+    if (!sessionUser) return { ok: false, message: 'Unauthorized' }
+    // Token must exist on server.
+    if (!DIRECTUS_TOKEN) return { ok: false, message: 'Server config missing' }
+
+    // Read JSON body from frontend.
+    const body = await request.json().catch(() => null)
+    if (!body) return { ok: false, message: 'Invalid request body' }
+
+    // I use session user id for secure update.
+    const userId = sessionUser.id
+    if (!userId) return { ok: false, message: 'Could not resolve user id for update' }
+
+    // Fields that can be edited in profile form.
+    const { name = '', institute = '', profession = '', email = '' } = body
+    // Main fields save first.
+    const corePayload = {
+      name: String(name).trim(),
+      institute: String(institute).trim(),
+      profession: String(profession).trim()
+    }
+
+    // Update main fields in Directus.
+    const updateResponse = await patchUser({ fetch, userId, payload: corePayload })
+    if (!updateResponse.ok) {
+      const details = await updateResponse.text().catch(() => '')
+      return { ok: false, message: 'Failed to save core profile fields', details }
+    }
+
+    // Optional warnings list (for non blocking fields).
+    const warnings = []
+    // Email update separated, so if email fail core fields still saved.
+    if (String(email).trim()) {
+      const emailResponse = await patchUser({ fetch, userId, payload: { email: String(email).trim() } })
+      if (!emailResponse.ok) warnings.push('Email could not be updated')
+    }
+
+    // Return success response to frontend.
+    const result = await updateResponse.json().catch(() => ({}))
+    return { ok: true, data: result?.data ?? corePayload, warnings }
+  },
+
+  // This action upload avatar photo file.
+  // Called from: /profile?/uploadAvatar
+  uploadAvatar: async ({ request, fetch, locals }) => {
+    const sessionUser = locals.user
+    // Must be logged in.
+    if (!sessionUser) return { ok: false, message: 'Unauthorized' }
+    // Token must exist on server.
+    if (!DIRECTUS_TOKEN) return { ok: false, message: 'Server config missing' }
+
+    // I use session user id for secure update.
+    const userId = sessionUser.id
+    if (!userId) return { ok: false, message: 'Could not resolve user id for update' }
+
+    // Read form-data and get uploaded avatar file.
+    const form = await request.formData().catch(() => null)
+    const avatar = form?.get('avatar')
+    if (!(avatar instanceof File)) return { ok: false, message: 'No avatar file uploaded' }
+
+    // Upload file first to Directus files endpoint.
+    const uploadBody = new FormData()
+    uploadBody.append('file', avatar)
+    const uploadResponse = await fetch(`${DIRECTUS_URL}/files`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${DIRECTUS_TOKEN}` },
+      body: uploadBody
+    })
+
+    if (!uploadResponse.ok) {
+      const details = await uploadResponse.text().catch(() => '')
+      return { ok: false, message: 'Avatar upload failed', details }
+    }
+
+    const uploadData = await uploadResponse.json().catch(() => null)
+    const photoId = uploadData?.data?.id
+    if (!photoId) return { ok: false, message: 'Upload succeeded but file id missing' }
+
+    // Then save returned file id into user photo field.
+    const photoResponse = await patchUser({ fetch, userId, payload: { photo: photoId } })
+    if (!photoResponse.ok) {
+      const details = await photoResponse.text().catch(() => '')
+      return { ok: false, message: 'Avatar uploaded but profile photo update failed', details }
+    }
+
+    // Return photo id so frontend can show new image directly.
+    return { ok: true, photo: photoId }
+  }
 }

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -80,7 +80,11 @@ export const actions = {
     const warnings = []
     // Email update separated, so if email fail core fields still saved.
     if (String(email).trim()) {
-      const emailResponse = await patchUser({ fetch, userId, payload: { email: String(email).trim() } })
+      const emailResponse = await patchUser({
+        fetch,
+        userId,
+        payload: { email: String(email).trim() }
+      })
       if (!emailResponse.ok) warnings.push('Email could not be updated')
     }
 

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,10 +1,148 @@
 <script>
   import GroupsLink from '$lib/components/profile/GroupsLink.svelte'
-
+  import EditActions from '$lib/components/profile/EditActions.svelte'
   import ProfileHero from "$lib/components/profile/ProfileHero.svelte";
   import ProfileInfo from "$lib/components/profile/ProfileInfo.svelte";
   let { data } = $props();
   const user = $derived(data.user);
+
+  // Build a safe UI model from the user object (prevents undefined values in inputs).
+  const createFormData = (sourceUser = {}) => ({
+    name: sourceUser?.name ?? '',
+    role: Array.isArray(sourceUser?.role) ? sourceUser.role.join(', ') : (sourceUser?.role ?? ''),
+    institute: sourceUser?.institute ?? '',
+    profession: sourceUser?.profession ?? '',
+    email: sourceUser?.email ?? ''
+  });
+
+  // UI mode flags for edit/save/avatar-upload actions.
+  let isEditing = $state(false);
+  let isSaving = $state(false);
+  let isUploadingAvatar = $state(false);
+  // Last saved values and currently edited values.
+  let savedProfile = $state(createFormData());
+  let formData = $state(createFormData());
+  // Local avatar id so uploaded photo appears immediately.
+  let currentAvatarId = $state(null);
+  // Toast state and timer for temporary feedback messages.
+  let toastMessage = $state('');
+  let toastTimer;
+
+  // Sync local editable state from a user source.
+  function resetFromUser(sourceUser) {
+    const nextData = createFormData(sourceUser);
+    savedProfile = { ...nextData };
+    formData = { ...nextData };
+  }
+
+  // Initialize profile state once user data is available.
+  $effect(() => {
+    if (!savedProfile.email && user) {
+      resetFromUser(user);
+    }
+    if (!currentAvatarId && user?.photo) {
+      currentAvatarId = user.photo;
+    }
+  });
+
+  // Update one field in the editable form state.
+  function onFieldChange(field, value) {
+    formData = { ...formData, [field]: value };
+  }
+
+  // Show temporary feedback at the bottom of the page.
+  function showToast(message) {
+    toastMessage = message;
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => {
+      toastMessage = '';
+    }, 2200);
+  }
+
+  async function parseServerResult(response) {
+    const payload = await response.json().catch(() => null);
+    if (!payload) return null;
+    return payload?.data && payload?.type ? payload.data : payload;
+  }
+
+  // Enter edit mode and restore draft from last saved profile.
+  function startEdit() {
+    formData = { ...savedProfile };
+    isEditing = true;
+  }
+
+  // Exit edit mode without persisting changes.
+  function cancelEdit() {
+    formData = { ...savedProfile };
+    isEditing = false;
+    showToast('Editing cancelled');
+  }
+
+  // Persist profile fields to server and keep local state in sync.
+  async function saveEdit() {
+    if (isSaving) return;
+    isSaving = true;
+
+    try {
+      const response = await fetch('/profile?/saveProfile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId: user?.id,
+          ...formData
+        })
+      });
+
+      const result = await parseServerResult(response);
+      if (!response.ok || !result?.ok) {
+        showToast(result?.message || 'Could not save profile');
+        return;
+      }
+
+      savedProfile = { ...formData };
+      isEditing = false;
+      if (result?.warnings?.length) {
+        showToast(`Saved with warning: ${result.warnings[0]}`);
+        return;
+      }
+
+      showToast('Profile changes saved');
+    } catch {
+      showToast('Could not save profile');
+    } finally {
+      isSaving = false;
+    }
+  }
+
+  // Upload avatar through the same /profile endpoint.
+  async function uploadAvatar(file) {
+    if (isUploadingAvatar || !file) return;
+    isUploadingAvatar = true;
+
+    try {
+      const payload = new FormData();
+      payload.append('avatar', file);
+
+      const response = await fetch('/profile?/uploadAvatar', {
+        method: 'POST',
+        body: payload
+      });
+
+      const result = await parseServerResult(response);
+      if (!response.ok || !result?.ok || !result?.photo) {
+        showToast(result?.message || 'Could not upload profile photo');
+        return;
+      }
+
+      currentAvatarId = result.photo;
+      showToast('Profile photo updated');
+    } catch {
+      showToast('Could not upload profile photo');
+    } finally {
+      isUploadingAvatar = false;
+    }
+  }
+
 </script>
 
 
@@ -13,13 +151,22 @@
   <h1 class="profile-title">Profile</h1>
 
   <article class="profile-card">
-    <ProfileHero {user} />
-    <ProfileInfo {user} />
+    <EditActions {isEditing} disabled={isSaving} onStartEdit={startEdit} onSave={saveEdit} onCancel={cancelEdit} />
+    <ProfileHero
+      {user}
+      {isEditing}
+      {formData}
+      {onFieldChange}
+      avatarId={currentAvatarId}
+      onAvatarUpload={uploadAvatar}
+    />
+    <ProfileInfo {isEditing} {formData} {onFieldChange} />
     <GroupsLink />
   </article>
 
-
-
+  {#if toastMessage}
+    <div class="toast" role="status" aria-live="polite">{toastMessage}</div>
+  {/if}
 </section>
 
 <style>
@@ -34,12 +181,26 @@
     }
 
     .profile-card {
+      position: relative;
       background: var(--background-color-primary);
       border-radius: var(--radius-lg);
       box-shadow: var(--shadow-sm);
       overflow: hidden;
       container-type: inline-size;
       container-name: profile-card;
+    }
+
+    .toast {
+      position: fixed;
+      bottom: 1.8rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--blue-500);
+      color: var(--background-color-primary);
+      padding: 0.55rem 1rem;
+      border-radius: var(--radius-sm);
+      box-shadow: var(--shadow-sm);
+      z-index: 10;
     }
   }
 


### PR DESCRIPTION
## What does this change?


- This is the main branch  Individual pieces were reviewed on sub-branches before being merged here.


Resolves issue #259 
Implements the full profile editing feature. Users can now edit their name, profession, institution, email, and avatar photo directly on the profile page. 
This PR covers everything new components, server actions, client state management, and style guide additions.

**Why this was needed:**
The profile page was fully read-only. 
User using FootGuard had no way to update their own profile data without going through Directus directly.

**What's included:**

`EditActions.svelte` — new component with Edit / Save / Cancel buttons. 

`ProfileHero.svelte` — extended to support edit mode: name, profession and avatar.


`ProfileInfo.svelte` — institution, profession, and email toggle between 

`+page.server.js`  two new server actions:
- `saveProfile`: validates session, PATCHes core fields.

- `uploadAvatar`: uploads file to Directus `/files`, then patches the 
  user photo.



`styleguide.css` added `.sr-only` utility class used on labels inside ProfileHero for the screen reader.


## How Has This Been Tested?

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images
<img width="1263" height="734" alt="Screenshot 2026-03-31 at 16 36 59" src="https://github.com/user-attachments/assets/3427915f-003e-481b-bfef-d07b593c5c3e" />
<img width="935" height="221" alt="Screenshot 2026-03-31 at 16 39 39" src="https://github.com/user-attachments/assets/1da11144-d97f-4e0d-aa29-04b8dff1e936" />

## How to review

1. Go to this  branch 
2. Open your profile page data should load fresh from Directus
3. Click **Edit Profile** —name, profession, institution, and email 
   become editable; role stays readonly
4. Edit a field and click **Save Changes** confirm changes persist 
   after a page reload and are updated in Directus
5. Click **Edit** then **Cancel** — all fields should revert to last 
   saved values
6. Click the avatar **Change photo** button — file picker should open; 
   select an image and confirm it updates immediately without a reload
7. Tab through all interactive elements in edit mode and confirm 
   focus-visible outlines appear correctly
