### PR TITLE
feat: add logout icon and button to navbar. #306

### DIFF
--- a/src/lib/components/layout/MobileNav.svelte
+++ b/src/lib/components/layout/MobileNav.svelte
@@ -8,6 +8,7 @@
 		ResultsIcon,
 		SettingIcon,
 		IwgdfLogo,
+		LogoutIcon,
 	} from "$lib";
 
 	import { resolve } from "$app/paths";
@@ -84,6 +85,12 @@
 				<span class="label">Settings</span>
 			</a>
 		</li>
+		 <li>
+    <a href={resolve("/logout")} aria-label="Log out">
+      <span class="icon"><LogoutIcon /></span>
+      <span class="label">Log out</span>
+    </a>
+  </li>
 	</ul>
 </nav>
 
@@ -164,6 +171,12 @@
 			}
 		}
 	}
+	li:last-child a {
+  &:hover {
+    background: var(--red-100, #fee2e2);
+    color: var(--red-600, #dc2626);
+  }
+}
 	
 	.icon {
 		display: inline-flex;

--- a/src/lib/components/layout/Navbar.svelte
+++ b/src/lib/components/layout/Navbar.svelte
@@ -4,6 +4,7 @@
     CollapseMenuIcon,
     DashboardIcon,
     GradingIcon,
+    LogoutIcon,
     NotificationIcon,
     ProfileIcon,
     ResultsIcon,
@@ -93,6 +94,14 @@
       </li>
     {/if}
   </ul>
+    {#if user}
+    <div class="logout">
+      <a href={resolve("/logout")} aria-label="Log out" class="logout-link">
+        <span class="icon"><LogoutIcon /></span>
+        <span class="label">Log out</span>
+      </a>
+    </div>
+  {/if}
 </nav>
 
 
@@ -151,6 +160,7 @@
         display: flex;
         flex-direction: column;
         gap: 10px;
+		flex: 1;
 
         li{
             justify-content: center;
@@ -174,9 +184,29 @@
 				}
             }    
         }
-	}
-	
-	.icon{
+}
+.logout-link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--main-svg-icon-color);
+  font-weight: 500;
+  padding: 10px 25px;
+  border-radius: 100px;
+
+  &:hover {
+    background: var(--red-100, #fee2e2);
+    color: var(--red-600, #dc2626);
+  }
+}
+
+.logout {
+  margin-top: auto;
+  padding: 0 0 0.5em 0;
+}
+
+.icon{
 		display: inline-flex;
 	}
 

--- a/src/lib/components/navbar-icons/logout-icon.svelte
+++ b/src/lib/components/navbar-icons/logout-icon.svelte
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <path
+    d="M18 42H10C8.93913 42 7.92172 41.5786 7.17157 40.8284C6.42143 40.0783 6 39.0609 6 38V10C6 8.93913 6.42143 7.92172 7.17157 7.17157C7.92172 6.42143 8.93913 6 10 6H18M32 34L42 24M42 24L32 14M42 24H18"
+    stroke="currentColor"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -15,6 +15,7 @@ export { default as IwgdfLogo } from './components/navbar-icons/IWGDF-Logo.svelt
 export { default as IwgdfLogoCollapsed } from './components/navbar-icons/IWGDGF-Logo-Collapsed.svelte'
 export { default as IwgdfLogoMobile } from './components/navbar-icons/IWGDF-Logo-Mobile.svelte'
 export { default as HamburgerMenuIcon } from './components/navbar-icons/hamburger-menu-icon.svelte'
+export { default as LogoutIcon } from './components/navbar-icons/logout-icon.svelte'
 
 //Notifications page
 export { default as NotificationItem } from './components/NotificationItem.svelte'


### PR DESCRIPTION
## What does this change?

Resolves issue #306 

Currently there was no visible logout option in the navigation bar, making it unclear for users how to log out of the application. This is especially confusing for users who share a device.

This PR adds a logout icon button to the bottom of the navbar that is visible on all pages when the user is logged in. Clicking it calls the existing `/logout` route, which deletes the session cookie and redirects to `/login`.

Changes:
- Added `logout-icon.svelte` to `src/lib/components/navbar-icons/`
- Exported `LogoutIcon` from `$lib`
- Updated the navbar layout component to include the logout button at the bottom
- Logout button is only rendered when `locals.user` exists
- Styled consistently with existing navbar items, with a red hover state to indicate a destructive action

[livesite](https://livesite.com)

## How Has This Been Tested?
- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images
| Before | After |
|--------|-------|
<img width="239" height="760" alt="Screenshot 2026-04-01 at 16 40 37" src="https://github.com/user-attachments/assets/7a3495f2-e68a-40b8-8f10-e1a1a4424f99" />

<img width="259" height="715" alt="Screenshot 2026-04-01 at 16 42 38" src="https://github.com/user-attachments/assets/d6075840-19e5-41b7-9a72-121c092e9c12" />

## How to review
1. Check out this branch and run the app locally
2. Log in with any account
3. Verify the logout icon appears at the bottom of the navbar
4. Click the logout icon and verify you are redirected to `/login` and the session is cleared
5. Verify the logout button is not visible when no user is logged in
6. Verify the icon is visible and centered in collapsed navbar state