### PR TITLE
325 user story fetch groups from api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 DIRECTUS_TOKEN=
-PUBLIC_DIRECTUS_URL=https://fdnd-agency.directus.app
-DIRECTUS_URL=https://fdnd-agency.directus.app
-PUBLIC_APP_URL=https://footguard.dev.fdnd.nl
+PUBLIC_DIRECTUS_URL=
+DIRECTUS_URL=
+PUBLIC_APP_URL=
 EMAIL_PROVIDER=resend
-MAIL_FROM=no-reply@fdnd.nl
+MAIL_FROM=

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 DIRECTUS_TOKEN=
 PUBLIC_DIRECTUS_URL=https://fdnd-agency.directus.app
+DIRECTUS_URL=https://fdnd-agency.directus.app
 PUBLIC_APP_URL=https://footguard.dev.fdnd.nl
 EMAIL_PROVIDER=resend
 MAIL_FROM=no-reply@fdnd.nl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,6 @@ jobs:
 
       - name: Build project
         run: npm run build
-        env: 
-        DIRECTUS_URL: ${{ secrets.DIRECTUS_URL }}          
-        DIRECTUS_TOKEN: ${{ secrets.DIRECTUS_TOKEN }}
+        env:
+          DIRECTUS_URL: ${{ secrets.DIRECTUS_URL }}
+          DIRECTUS_TOKEN: ${{ secrets.DIRECTUS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -43,3 +44,5 @@ jobs:
 
       - name: Build project
         run: npm run build
+        env:          DIRECTUS_URL: ${{ secrets.DIRECTUS_URL }}          
+        DIRECTUS_TOKEN: ${{ secrets.DIRECTUS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,6 @@ jobs:
 
       - name: Build project
         run: npm run build
-        env:          DIRECTUS_URL: ${{ secrets.DIRECTUS_URL }}          
+        env: 
+        DIRECTUS_URL: ${{ secrets.DIRECTUS_URL }}          
         DIRECTUS_TOKEN: ${{ secrets.DIRECTUS_TOKEN }}

--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -15,13 +15,20 @@
   $: memberCount = group?.memberCount ?? 0;
 
 
+ // Max number of member avatars to show in the preview
+  const MAX_PREVIEW_MEMBERS = 2;
+
+  // Reactive plural check to avoid magic numbers in the template
+  $: isPlural = memberCount !== 1;
+
   // Create temporary preview items with stable ids for rendering
-$: previewMembers =
-  memberCount > 0
-    ? Array.from({ length: Math.min(memberCount, 2) }, (_, index) => ({
-        id: index + 1
-      }))
-    : [];
+  $: previewMembers =
+    memberCount > 0
+      ? Array.from({ length: Math.min(memberCount, MAX_PREVIEW_MEMBERS) }, (_, index) => ({
+          id: index + 1,
+          name: null // Name is not available yet until member API data is connected
+        }))
+      : [];
 </script>
 
 <article>
@@ -35,10 +42,10 @@ $: previewMembers =
     <h2 class="title">Members</h2>
 
     <!-- Temporary member preview until real member data is available -->
-    {#if previewMembers.length > 0}
-  <ul aria-label="Current members preview">
-    {#each previewMembers as member (member.id)}
-  <li>
+  {#if previewMembers.length > 0}
+      <ul aria-label="Current members preview">
+        {#each previewMembers as member (member.id)}
+          <li>
     <img src={avatar} alt={`Group member ${member.id}`} />
   </li>
 {/each}
@@ -53,7 +60,7 @@ $: previewMembers =
   <details>
     <summary>
        <!-- Member count is currently based on fallback data -->
-      <span>{memberCount} member{memberCount === 1 ? '' : 's'}</span>
+       <span>{memberCount} member{isPlural ? 's' : ''}</span>
       <span class="chevron">
         <DetailsUpIcon />
       </span>

--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -4,29 +4,56 @@
   import GroupInviteForm from "$lib/components/groups/GroupInviteForm.svelte";
   import UserSectionDropdown from "$lib/components/groups/UserSectionDropdown.svelte";
   import avatar from "$lib/assets/img/profile-avatar.webp";
+
+  // Group data is passed from the groups page
+  export let group;
+
+  // Fallback values keep the component safe while API data is still incomplete
+  $: groupName = group?.name ?? "Unnamed group";
+  $: groupStatus = group?.status ?? "Unknown";
+  $: conditionLabel = group?.conditionlabel ?? "General";
+  $: memberCount = group?.memberCount ?? 0;
+
+
+  // Create temporary preview items with stable ids for rendering
+$: previewMembers =
+  memberCount > 0
+    ? Array.from({ length: Math.min(memberCount, 2) }, (_, index) => ({
+        id: index + 1
+      }))
+    : [];
 </script>
 
 <article>
-  <GroupCardHeader />
+  <GroupCardHeader
+  name={groupName}
+  status={groupStatus}
+  conditionLabel={conditionLabel}
+/>
 
   <section class="members-section">
     <h2 class="title">Members</h2>
-    <!-- TODO: Replace hardcoded member avatars with dynamic group member data from load/server. -->
-    <ul aria-label="Current members preview">
-      <li>
-        <img src={avatar} alt="User 1 name" />
-      </li>
-      <li>
-        <img src={avatar} alt="User 2 name" />
-      </li>
-    </ul>
+
+    <!-- Temporary member preview until real member data is available -->
+    {#if previewMembers.length > 0}
+  <ul aria-label="Current members preview">
+    {#each previewMembers as member (member.id)}
+  <li>
+    <img src={avatar} alt={`Group member ${member.id}`} />
+  </li>
+{/each}
+  </ul>
+{:else}
+  <p class="members-empty">No members available yet.</p>
+{/if}
+
     <GroupInviteForm />
   </section>
 
   <details>
     <summary>
-      <!-- TODO: Compute this count from dynamic member data once API integration is in place. -->
-      <span>2 of 2 members</span>
+       <!-- Member count is currently based on fallback data -->
+      <span>{memberCount} member{memberCount === 1 ? '' : 's'}</span>
       <span class="chevron">
         <DetailsUpIcon />
       </span>

--- a/src/lib/components/groups/GroupCardHeader.svelte
+++ b/src/lib/components/groups/GroupCardHeader.svelte
@@ -1,5 +1,15 @@
 <script>
   import groupHeaderPhoto from "$lib/assets/img/charcot-icon.webp";
+
+  // Dynamic group data passed from GroupCard.svelte
+  export let name;
+  export let status;
+  export let conditionLabel;
+
+  // Fallback values keep the header safe while API data is still incomplete
+  $: groupName = name ?? "Unnamed group";
+  $: groupStatus = status ?? "Unknown";
+  $: groupConditionLabel = conditionLabel ?? "General";
 </script>
 
 <section>
@@ -7,10 +17,10 @@
     <!-- TODO: Replace static header image with group avatar from dynamic group data. -->
     <img src={groupHeaderPhoto} alt="Group icon" />
   </div>
-  <h2>Charcot's neuro-osteo-arthropathy</h2>
+  <h2>{groupName}</h2>
   <ul>
-    <li>CHARCOT</li>
-    <li>ACTIVE</li>
+    <li>{groupConditionLabel}</li>
+    <li>{groupStatus}</li>
   </ul>
 </section>
 

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -2,8 +2,7 @@
 // Service to fetch all available workgroups from the Directus API.
 // Uses the footguard_workgroups collection.
 
-import { PUBLIC_DIRECTUS_URL } from '$env/static/public'
-import { DIRECTUS_TOKEN } from '$env/static/private'
+import { DIRECTUS_URL, DIRECTUS_TOKEN } from '$env/static/private'
 /**
  * Fetches all workgroups from Directus.
  * Member count is 0 for now since footguard_group_members has no data yet.
@@ -12,7 +11,7 @@ import { DIRECTUS_TOKEN } from '$env/static/private'
  * @throws {Error} If the API call fails
  */
 export async function fetchGroups() {
-  const url = `${PUBLIC_DIRECTUS_URL}/items/footguard_workgroups?fields=id,group_name,status,condition_label,created_by_user_id`
+  const url = `${DIRECTUS_URL}/items/footguard_workgroups?fields=id,group_name,status,condition_label,created_by_user_id`
 
   const response = await fetch(url, {
     headers: {

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -1,0 +1,38 @@
+/** @author:Razan Sagheer **/
+// Service to fetch all available workgroups from the Directus API.
+// Uses the footguard_workgroups collection.
+
+import { DIRECTUS__URL, DIRECTUS_TOKEN } from '$env/static/private'
+
+/**
+ * Fetches all workgroups from Directus.
+ * Member count is 0 for now since footguard_group_members has no data yet.
+ *
+ * @returns {Promise<Array>} List of workgroup objects
+ * @throws {Error} If the API call fails
+ */
+export async function fetchGroups() {
+  const url = `${DIRECTUS__URL}/items/footguard_workgroups?fields=id,group_name,status,condition_label,created_by_user_id`
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${DIRECTUS_TOKEN}`,
+      'Content-Type': 'application/json'
+    }
+  })
+
+  if (!response.ok) {
+    throw new Error(`Directus API error: ${response.status} ${response.statusText}`)
+  }
+
+  const json = await response.json()
+
+  // Map the raw Directus response to a clean UI-friendly format
+  return json.data.map((group) => ({
+    id: group.id,
+    name: group.group_name,
+    status: group.status,
+    conditionlabel: group.condition_label ?? 'General', // fallback if null
+    memberCount: 0 // footguard_group_members is empty for now
+  }))
+}

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -2,8 +2,8 @@
 // Service to fetch all available workgroups from the Directus API.
 // Uses the footguard_workgroups collection.
 
-import { DIRECTUS__URL, DIRECTUS_TOKEN } from '$env/static/private'
-
+import { PUBLIC_DIRECTUS_URL } from '$env/static/public'
+import { DIRECTUS_TOKEN } from '$env/static/private'
 /**
  * Fetches all workgroups from Directus.
  * Member count is 0 for now since footguard_group_members has no data yet.
@@ -12,7 +12,7 @@ import { DIRECTUS__URL, DIRECTUS_TOKEN } from '$env/static/private'
  * @throws {Error} If the API call fails
  */
 export async function fetchGroups() {
-  const url = `${DIRECTUS__URL}/items/footguard_workgroups?fields=id,group_name,status,condition_label,created_by_user_id`
+  const url = `${PUBLIC_DIRECTUS_URL}/items/footguard_workgroups?fields=id,group_name,status,condition_label,created_by_user_id`
 
   const response = await fetch(url, {
     headers: {

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -13,13 +13,21 @@ import { DIRECTUS_URL, DIRECTUS_TOKEN } from '$env/static/private'
 export async function fetchGroups() {
   const url = `${DIRECTUS_URL}/items/footguard_workgroups?fields=id,group_name,status,condition_label,created_by_user_id`
 
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${DIRECTUS_TOKEN}`,
-      'Content-Type': 'application/json'
-    }
-  })
+  let response
 
+  try {
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${DIRECTUS_TOKEN}`,
+        'Content-Type': 'application/json'
+      }
+    })
+  } catch (networkError) {
+    // Fetch itself failed (e.g. no internet, Directus unreachable)
+    throw new Error(`Network error while connecting to Directus: ${networkError.message}`)
+  }
+
+  // Handle non-2xx HTTP responses from Directus
   if (!response.ok) {
     throw new Error(`Directus API error: ${response.status} ${response.statusText}`)
   }

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,16 +1,17 @@
 <script>
     import { resolve } from "$app/paths";
+    import { page } from '$app/stores';
   </script>  
 <section class="error-container">
-    <h1>404 - This page does not exist</h1>
-    <p class="link-container">Go back to the
-        <a href={resolve("/")} class="dashboard-link">Dashboard</a>
-        <svg class="svg-arrow" viewBox="0 0 24 24">
-            <path
-                d="M20.707 15.293 12.414 7l2.293-2.293A1 1 0 0 0 14 3H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1.707.707L7 12.414l8.293 8.293a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0 0-1.414z"
-                style="fill:#ff891a"
-            />
-        </svg>
+  <h1>{$page.status} - {$page.error?.message ?? 'Something went wrong'}</h1>
+  <p class="link-container">Go back to the
+    <a href={resolve("/")} class="dashboard-link">Dashboard</a>
+    <svg class="svg-arrow" viewBox="0 0 24 24">
+      <path
+        d="M20.707 15.293 12.414 7l2.293-2.293A1 1 0 0 0 14 3H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1.707.707L7 12.414l8.293 8.293a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0 0-1.414z"
+        style="fill:#ff891a"
+      />
+    </svg>
     </p>
 </section>
 

--- a/src/routes/groups/+page.server.js
+++ b/src/routes/groups/+page.server.js
@@ -3,7 +3,6 @@
 // The API token stays secure because this code only runs on the server.
 
 import { fetchGroups } from '$lib/server/groups.js'
-import { error } from '@sveltejs/kit'
 
 /**  @type {import('./$types').PageServerLoad}  */
 export async function load() {
@@ -11,9 +10,17 @@ export async function load() {
     const groups = await fetchGroups()
 
     // Pass groups to +page.svelte via the 'data' prop
-    return { groups }
+    return {
+      groups,
+      loadError: null
+    }
   } catch (err) {
     console.error('[groups] Failed to load groups from Directus:', err)
-    throw error(500, 'Could not load groups. Please try again later.')
+
+    // Return a safe fallback so the page can render an inline error state
+    return {
+      groups: [],
+      loadError: 'Could not load groups. Please try again later.'
+    }
   }
 }

--- a/src/routes/groups/+page.server.js
+++ b/src/routes/groups/+page.server.js
@@ -3,24 +3,20 @@
 // The API token stays secure because this code only runs on the server.
 
 import { fetchGroups } from '$lib/server/groups.js'
+import { error } from '@sveltejs/kit'
 
-/**  @type {import('./$types').PageServerLoad}  */
+/** @type {import('./$types').PageServerLoad} */
 export async function load() {
   try {
     const groups = await fetchGroups()
 
-    // Pass groups to +page.svelte via the 'data' prop
+    // Pass groups to +page.svelte via the `data` prop
     return {
       groups,
       loadError: null
     }
-  } catch (err) {
-    console.error('[groups] Failed to load groups from Directus:', err)
-
-    // Return a safe fallback so the page can render an inline error state
-    return {
-      groups: [],
-      loadError: 'Could not load groups. Please try again later.'
-    }
+  } catch {
+    // Throw a proper SvelteKit error with status code
+    throw error(500, 'Could not load groups. Please try again later.')
   }
 }

--- a/src/routes/groups/+page.server.js
+++ b/src/routes/groups/+page.server.js
@@ -1,0 +1,19 @@
+/** @author:Razan Sagheer **/
+// Fetches workgroup data from Directus before the page renders.
+// The API token stays secure because this code only runs on the server.
+
+import { fetchGroups } from '$lib/server/groups.js'
+import { error } from '@sveltejs/kit'
+
+/**  @type {import('./$types').PageServerLoad}  */
+export async function load() {
+  try {
+    const groups = await fetchGroups()
+
+    // Pass groups to +page.svelte via the 'data' prop
+    return { groups }
+  } catch (err) {
+    console.error('[groups] Failed to load groups from Directus:', err)
+    throw error(500, 'Could not load groups. Please try again later.')
+  }
+}

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -12,6 +12,9 @@
   // Uses a fallback empty array to prevent errors when no data is available yet.
   $: groups = data.groups ?? [];
   $: loadError = data.loadError ?? null;
+
+  // Loading state is true until groups or an error value is available
+  $: isLoading = !data?.groups && !data?.loadError;
 </script>
 
 <section class="groups-page">
@@ -24,12 +27,16 @@
       Manage members, invite users by email, and quickly update group access.
     </GroupAboutBanner>
     <GroupFilter />
-    {#if loadError}
+  {#if isLoading}
+  <!-- Loading state -->
+  <p>Loading groups...</p>
+
+{:else if loadError}
   <!-- Error state -->
   <p>Something went wrong while loading groups.</p>
 
 {:else if groups.length === 0}
-  <!-- Empty state (VERY IMPORTANT for your situation) -->
+  <!-- Empty state -->
   <p>No groups found yet. Directus connection works, but there is no data in the database.</p>
 
 {:else}

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -2,6 +2,14 @@
   import GroupAboutBanner from "$lib/components/groups/GroupAboutBanner.svelte";
   import GroupCard from "$lib/components/groups/GroupCard.svelte";
   import GroupFilter from "$lib/components/groupFilter/GroupFilter.svelte"
+
+  // `data` is injected by SvelteKit from +page.server.js
+  // It contains the groups array fetched from Directus
+  export let data;
+
+  // Extract groups safely (fallback to empty array)
+  const groups = data.groups ?? [];
+  const loadError = data.loadError ?? null;
 </script>
 
 <section class="groups-page">
@@ -14,9 +22,28 @@
       Manage members, invite users by email, and quickly update group access.
     </GroupAboutBanner>
     <GroupFilter />
-    <div class="groups-cards">
-      <GroupCard />
-    </div>
+    {#if loadError}
+  <!-- Error state -->
+  <p>Something went wrong while loading groups.</p>
+
+{:else if groups.length === 0}
+  <!-- Empty state (VERY IMPORTANT for your situation) -->
+  <p>No groups found yet. Directus connection works, but there is no data in the database.</p>
+
+{:else}
+  <!-- Success state -->
+  <div class="groups-cards">
+    {#each groups as group (group.id)}
+      <GroupCard
+        groupId={group.id}
+        name={group.name}
+        status={group.status}
+        conditionLabel={group.conditionlabel}
+        memberCount={group.memberCount}
+      />
+    {/each}
+  </div>
+{/if}
   </article>
 </section>
 

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -8,8 +8,10 @@
   export let data;
 
   // Extract groups safely (fallback to empty array)
-  const groups = data.groups ?? [];
-  const loadError = data.loadError ?? null;
+  // Reactive statement: automatically updates `groups` whenever `data.groups` changes.
+  // Uses a fallback empty array to prevent errors when no data is available yet.
+  $: groups = data.groups ?? [];
+  $: loadError = data.loadError ?? null;
 </script>
 
 <section class="groups-page">
@@ -34,13 +36,7 @@
   <!-- Success state -->
   <div class="groups-cards">
     {#each groups as group (group.id)}
-      <GroupCard
-        groupId={group.id}
-        name={group.name}
-        status={group.status}
-        conditionLabel={group.conditionlabel}
-        memberCount={group.memberCount}
-      />
+      <GroupCard {group} />
     {/each}
   </div>
 {/if}

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -33,11 +33,11 @@
 
 {:else if loadError}
   <!-- Error state -->
-  <p>Something went wrong while loading groups.</p>
+  <p class="groups-status groups-status--error">Something went wrong while loading groups.</p>
 
 {:else if groups.length === 0}
-  <!-- Empty state -->
-  <p>No groups found yet. Directus connection works, but there is no data in the database.</p>
+      <!-- Empty state -->
+      <p class="groups-status">No groups available at the moment. Check back later!</p>
 
 {:else}
   <!-- Success state -->
@@ -77,6 +77,15 @@
       flex-wrap: wrap;
       gap: var(--spacing-lg);
       justify-content: flex-start;
+    }
+   .groups-status {
+      color: var(--grey-500);
+      text-align: center;
+      padding: var(--spacing-xl) 0;
+    }
+
+    .groups-status--error {
+      color: var(--color-danger, #dc2626);
     }
   }
 


### PR DESCRIPTION
## What does this change?

Resolves issue #325 

This PR replaces the static/hardcoded group data on the groups page with dynamic data fetched from the Directus API.

**Problem**
Previously, the groups page used hardcoded content, which made it impossible to display real data from the backend or scale the feature.

**Solution**
This change connects the frontend to Directus and renders groups dynamically using server-side data fetching in SvelteKit.

**What was implemented**
- Created a fetchGroups() service to retrieve data from the footguard_workgroups collection
- Added a +page.server.js load function to fetch data securely on the server
- Replaced hardcoded group cards with dynamic rendering using {#each}
- Refactored GroupCard and GroupCardHeader to accept props instead of static content
- Added UI states:
- loading state
- error state
- empty state
- Mapped Directus response to a clean UI-friendly format


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [x] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

1. Run the project locally
2. Navigate to: /groups
3. Verify the following:
- Groups are fetched from Directus and rendered as cards
- No hardcoded group data is present
- Loading state appears briefly before data loads
- Error state appears if the API request fails (can be tested by breaking the API URL)
- Empty state appears if no groups exist in the database
4. Optional:
- Check Directus footguard_workgroups collection and confirm changes reflect in the UI after refresh
