### PR TITLE
fix: update group card member section styling and dropdown design. #333

### DIFF
--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -12,7 +12,14 @@
   $: groupName = group?.name ?? "Unnamed group";
   $: groupStatus = group?.status ?? "Unknown";
   $: conditionLabel = group?.conditionlabel ?? "General";
-  $: memberCount = group?.memberCount ?? 0;
+
+  // Members array from group data, fallback to empty array
+  // TODO: Replace with real member data from Directus when API is connected
+  $: members = group?.members?.length > 0 ? group.members : [
+  { id: 1, name: "Yamen Al", email: "yamen@example.com" },
+  { id: 2, name: "John Doe", email: "john@example.com" }
+];
+  $: memberCount = members.length > 0 ? members.length : (group?.memberCount ?? 0);
 
 
  // Max number of member avatars to show in the preview
@@ -38,25 +45,37 @@
   conditionLabel={conditionLabel}
 />
 
-  <section class="members-section">
+<section class="members-section">
     <h2 class="title">Members</h2>
 
-    <!-- Temporary member preview until real member data is available -->
-  {#if previewMembers.length > 0}
-      <ul aria-label="Current members preview">
-        {#each previewMembers as member (member.id)}
-          <li>
-    <img src={avatar} alt={`Group member ${member.id}`} />
-  </li>
-{/each}
-  </ul>
-{:else}
-  <p class="members-empty">No members available yet.</p>
-{/if}
+    <!-- Member avatar preview row with add button -->
+    <div class="members-preview">
+      {#if previewMembers.length > 0}
+        <ul aria-label="Current members preview">
+          {#each previewMembers as member (member.id)}
+            <li>
+              <!-- Avatar image is managed via Directus, no changes needed here -->
+              <img src={avatar} alt={member.name ?? `Group member ${member.id}`} />
+            </li>
+          {/each}
+        </ul>
+      {/if}
+
+      <!-- Add member button: dashed circle with plus icon next to avatars -->
+      <button class="btn-add" type="button" aria-label="Add team member">
+        +
+      </button>
+    </div>
+
+    {#if previewMembers.length === 0}
+      <!-- Empty state: shown when group has no members yet -->
+      <p class="members-empty">No members available yet.</p>
+    {/if}
 
     <GroupInviteForm />
   </section>
 
+  <!-- Expandable dropdown showing full member list -->
   <details>
     <summary>
        <!-- Member count is currently based on fallback data -->
@@ -65,7 +84,8 @@
         <DetailsUpIcon />
       </span>
     </summary>
-    <UserSectionDropdown />
+    <!-- Pass members array down to the dropdown component -->
+<UserSectionDropdown {members} />
   </details>
 </article>
 
@@ -81,11 +101,14 @@
     container-name: group-card;
   }
 
-  .members-section {
-    padding: var(--spacing-lg);
+    .members-preview {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    margin-bottom: var(--spacing-lg);
 
     ul {
-      margin: 0 0 var(--spacing-lg);
+      margin: 0;
       padding: 0;
       list-style: none;
       display: flex;
@@ -104,6 +127,32 @@
         box-shadow: var(--shadow-sm);
       }
     }
+  }
+
+    /* Dashed circle add button next to avatars */
+  .btn-add {
+    width: 3rem;
+    height: 3rem;
+    border-radius: var(--radius-full);
+    border: 2px dashed var(--grey-300);
+    background: transparent;
+    color: var(--grey-400);
+    font-size: 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: border-color var(--transition-fast), color var(--transition-fast);
+    flex-shrink: 0;
+
+    &:hover {
+      border-color: var(--grey-500);
+      color: var(--grey-600);
+    }
+  }
+
+  .members-section {
+    padding: var(--spacing-lg);
   }
 
   summary {

--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -15,10 +15,11 @@
 
   // Members array from group data, fallback to empty array
   // TODO: Replace with real member data from Directus when API is connected
-  $: members = group?.members?.length > 0 ? group.members : [
-  { id: 1, name: "Yamen Al", email: "yamen@example.com" },
-  { id: 2, name: "John Doe", email: "john@example.com" }
-];
+//   $: members = group?.members?.length > 0 ? group.members : [
+//   { id: 1, name: "Yamen Al", email: "yamen@example.com" },
+//   { id: 2, name: "John Doe", email: "john@example.com" }
+// ];
+  $: members = group?.members ?? [];
   $: memberCount = members.length > 0 ? members.length : (group?.memberCount ?? 0);
 
 
@@ -61,10 +62,13 @@
         </ul>
       {/if}
 
-      <!-- Add member button: dashed circle with plus icon next to avatars -->
-      <button class="btn-add" type="button" aria-label="Add team member">
-        +
-      </button>
+      <!-- Add member button: dashed circle with SVG plus icon next to avatars -->
+<!-- Using SVG instead of + text for sharper rendering and better scaling -->
+<button class="btn-add" type="button" aria-label="Add team member">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+  </svg>
+</button>
     </div>
 
     {#if previewMembers.length === 0}
@@ -137,7 +141,6 @@
     border: 2px dashed var(--grey-300);
     background: transparent;
     color: var(--grey-400);
-    font-size: 1.25rem;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -145,9 +148,10 @@
     transition: border-color var(--transition-fast), color var(--transition-fast);
     flex-shrink: 0;
 
-    &:hover {
-      border-color: var(--grey-500);
-      color: var(--grey-600);
+    svg {
+    width: 1.25rem;
+    height: 1.25rem;
+
     }
   }
 

--- a/src/lib/components/groups/UserSectionDropdown.svelte
+++ b/src/lib/components/groups/UserSectionDropdown.svelte
@@ -1,80 +1,136 @@
 <script>
   import avatar from '$lib/assets/img/profile-avatar.webp';
+
+  // Members are passed from GroupCard.svelte
+  // Each member can have: id, name, email, isEmpty (open slot)
+  export let members = [];
 </script>
 
 <section>
   <h2 class="title">Group members details</h2>
   <!-- TODO: Replace this static member list with dynamic data from the group members. -->
-  <ul >
-    <li>
-      <img src={avatar} alt="User 1 name" />
-      <span>User 1 name</span>
-      <form method="POST" action="?/remove">
-        <input type="hidden" name="memberId" value="1" />
-        <button type="submit">Remove</button>
-      </form>
-    </li>
-    <li>
-      <img src={avatar} alt="User 2 name" />
-      <span>User 2 name</span>
-      <form method="POST" action="?/remove">
-        <input type="hidden" name="memberId" value="2" />
-        <button type="submit">Remove</button>
-      </form>
-    </li>
+   <ul>
+    {#each members as member (member.id)}
+       <li>
+        <!-- Member avatar image (managed via Directus, no changes needed here) -->
+        <img src={avatar} alt={member.name ?? 'Team member'} />
+
+        <!-- Member name -->
+        <span class="member-name">{member.name ?? 'Unknown'}</span>
+
+        <!-- Remove button: grey circle with minus icon only — no text, no red -->
+        <form method="POST" action="?/remove">
+          <input type="hidden" name="memberId" value={member.id} />
+          <button type="submit" class="btn-remove" aria-label="Remove member">
+            <!-- Minus icon inside the button -->
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M19 13H5v-2h14v2z"/>
+            </svg>
+          </button>
+        </form>
+      </li>
+    {/each}
+
+    <!-- Fallback: shown when no members are available yet -->
+    {#if members.length === 0}
+      <li class="empty-state">No members available yet.</li>
+    {/if}
   </ul>
 </section>
 
 <style>
   section {
-    container-type: inline-size;
-    container-name: members-dropdown;
+  container-type: inline-size;    
+  container-name: members-dropdown;    
+  padding: var(--spacing-sm) var(--spacing-lg);
+  }
 
-    ul {
-      margin: 0;
-      padding: 0;
-      list-style: none;
-      display: grid;
-      gap: var(--spacing-sm);
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: var(--spacing-sm);
+  }
 
-      li {
-        display: grid;
-        grid-template-columns: auto 1fr auto;
-        align-items: center;
-        gap: var(--spacing-sm);
-        padding: var(--spacing-xs) var(--spacing-sm);
-        width: 100%;
-      }
+li {
+    display: grid;
+    /* Avatar | name | remove button */
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm) var(--spacing-lg);
+    border-bottom: 1px solid var(--grey-100);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  img {
+    width: 2rem;
+    height: 2rem;
+    border-radius: var(--radius-full);
+    object-fit: cover;
+  }
+
+  .member-name {
+    color: var(--grey-700);
+    font-weight: 500;    
+    font-size: var(--font-size-sm);
+    text-align: left;
+  }
+
+  /* Remove button: grey circle background with minus icon — no red */
+  .btn-remove {
+    border: none;
+    background: var(--grey-100);
+    color: var(--grey-500);
+    border-radius: var(--radius-full);
+    width: 1.75rem;
+    height: 1.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background var(--transition-fast);
+
+    svg {
+      width: 1rem;
+      height: 1rem;
     }
 
-    img {
-      width: 2rem;
-      height: 2rem;
-      border-radius: var(--radius-full);
-      object-fit: cover;
-    }
-
-    span {
+    /* Slightly darker grey on hover */
+    &:hover {
+      background: var(--red-200);
       color: var(--grey-700);
-      text-align: left;
     }
+  }
 
-    button {
-      border: 0;
-      background: transparent;
-      color: var(--red-500);
-      justify-self: end;
-    }
+  .btn-remove svg {
+    width: 1rem;
+    height: 1rem;
+  }
 
+  /* Slightly darker on hover — still no red */
+  .btn-remove:hover {
+    color: var(--red-600);
+  }
+
+  /* Fallback empty state message */
+  .empty-state {
+    display: block;
+    color: var(--grey-500);
+    font-size: var(--font-size-sm);
+    padding: var(--spacing-md) var(--spacing-sm);
+    text-align: center;
   }
 
   @container members-dropdown (min-width: 42rem) {
-    section {
-      ul {
-        li {
-          gap: var(--spacing-md);
-        }
-      }
+    li {
+      gap: var(--spacing-md);
+      padding-inline: var(--spacing-xl);
     }
   }
 </style>


### PR DESCRIPTION

## What does this change?

Resolves issue #333

The group card UI has been updated to match the new design. 
The member section now shows avatars in a preview row with a dashed 
plus button to add new members. The dropdown member list has been 
improved with a grey minus button instead of a red remove button. 
The members array is now passed as a prop to the UserSectionDropdown 
component so it can render the correct member data.

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images


<img width="406" height="590" alt="Screenshot 2026-04-10 at 11 26 57" src="https://github.com/user-attachments/assets/b9af49b3-af72-4775-bd96-34d5a9c12c7b" />
<img width="414" height="682" alt="Screenshot 2026-04-10 at 11 30 14" src="https://github.com/user-attachments/assets/5481ad46-d9b5-4b44-98d1-4c656876268d" />
 

## How to review

1. Go to the `/groups` page
2. Open a group card
3. Check that the members preview shows avatars with a dashed + button
4. Click the member count to expand the dropdown
5. Verify the remove button shows a grey circle with minus icon — red
