### PR TITLE
refactor/profile page edit

### DIFF
--- a/src/lib/components/profile/EditActions.svelte
+++ b/src/lib/components/profile/EditActions.svelte
@@ -6,7 +6,7 @@
 
 <div class="top-actions">
   {#if !isEditMode}
-    <a class="btn btn-edit" href={resolve('/profile?edit=1')} aria-disabled={disabled || undefined}>
+    <a class="btn btn-edit" href={resolve('/profile?edit')} aria-disabled={disabled || undefined}>
       <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
         <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
         <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />

--- a/src/lib/components/profile/EditActions.svelte
+++ b/src/lib/components/profile/EditActions.svelte
@@ -1,19 +1,21 @@
 <script>
-  let { isEditing = false, disabled = false, onStartEdit, onSave, onCancel } = $props();
+  import { resolve } from '$app/paths'
+
+  let { isEditMode = false, disabled = false, formId = '' } = $props()
 </script>
 
 <div class="top-actions">
-  {#if !isEditing}
-    <button class="btn btn-edit" type="button" onclick={onStartEdit} {disabled}>
+  {#if !isEditMode}
+    <a class="btn btn-edit" href={resolve('/profile?edit=1')} aria-disabled={disabled || undefined}>
       <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
         <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
         <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
       </svg>
       Edit Profile
-    </button>
+    </a>
   {:else}
-    <button class="btn btn-cancel" type="button" onclick={onCancel} {disabled}>Cancel</button>
-    <button class="btn btn-save" type="button" onclick={onSave} {disabled}>
+    <a class="btn btn-cancel" href={resolve('/profile')} aria-disabled={disabled || undefined}>Cancel</a>
+    <button class="btn btn-save" type="submit" form={formId} {disabled}>
       <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
         <polyline points="20 6 9 17 4 12" />
       </svg>
@@ -42,10 +44,13 @@
       align-items: center;
       gap: var(--spacing-xs);
       transition: background var(--transition-base);
+      text-decoration: none;
 
-      &:disabled {
+      &:disabled,
+      &[aria-disabled='true'] {
         opacity: 0.75;
         cursor: not-allowed;
+        pointer-events: none;
       }
 
       &:focus-visible {
@@ -58,7 +63,7 @@
       background: rgb(255 255 255 / 25%);
       color: var(--background-color-primary);
 
-      &:hover:not(:disabled) {
+      &:hover:not(:disabled):not([aria-disabled='true']) {
         background: rgb(255 255 255 / 40%);
       }
     }
@@ -79,7 +84,7 @@
       border: 1.5px solid rgb(255 255 255 / 50%);
       color: var(--background-color-primary);
 
-      &:hover:not(:disabled) {
+      &:hover:not(:disabled):not([aria-disabled='true']) {
         background: rgb(255 255 255 / 28%);
       }
     }

--- a/src/lib/components/profile/ProfileHero.svelte
+++ b/src/lib/components/profile/ProfileHero.svelte
@@ -5,13 +5,11 @@
   const profileName = $derived(formData?.name || user?.name || 'Unknown user');
   const profession = $derived(formData?.profession || user?.profession || 'Unknown profession');
 
-  const avatarSrc = $derived.by(() => {
-    const pending = avatarId
-    if (typeof pending === 'string' && pending.startsWith('data:image/')) return pending
-    const id = pending ?? user?.photo
-    if (id) return `https://fdnd-agency.directus.app/assets/${id}`
-    return 'https://placehold.co/112x112'
-  })
+  const avatarSrc = $derived(
+    (avatarId ?? user?.photo)
+      ? `https://fdnd-agency.directus.app/assets/${avatarId ?? user?.photo}`
+      : 'https://placehold.co/112x112'
+  )
 
   // Reference to hidden file input used by "Change photo" button.
   let fileInput = $state();

--- a/src/lib/components/profile/ProfileHero.svelte
+++ b/src/lib/components/profile/ProfileHero.svelte
@@ -5,12 +5,13 @@
   const profileName = $derived(formData?.name || user?.name || 'Unknown user');
   const profession = $derived(formData?.profession || user?.profession || 'Unknown profession');
 
-  // Build avatar URL from uploaded preview id or existing user photo id.
-  const avatarSrc = $derived(
-    (avatarId ?? user?.photo)
-      ? `https://fdnd-agency.directus.app/assets/${avatarId ?? user?.photo}`
-      : 'https://placehold.co/112x112'
-  );
+  const avatarSrc = $derived.by(() => {
+    const pending = avatarId
+    if (typeof pending === 'string' && pending.startsWith('data:image/')) return pending
+    const id = pending ?? user?.photo
+    if (id) return `https://fdnd-agency.directus.app/assets/${id}`
+    return 'https://placehold.co/112x112'
+  })
 
   // Reference to hidden file input used by "Change photo" button.
   let fileInput = $state();
@@ -91,15 +92,12 @@
       position: relative;
 
       .profile-avatar {
+        display: block;
         width: 6rem;
         height: 6rem;
         border-radius: var(--radius-full);
-        border: 3px solid var(--background-color-primary);
-        background: linear-gradient(145deg, var(--green-200), var(--blue-300));
-        color: var(--background-color-primary);
-        display: grid;
-        place-items: center;
-        box-shadow: var(--shadow-sm);
+        object-fit: cover;
+        object-position: center;
       }
 
       .avatar-upload {
@@ -117,7 +115,7 @@
         cursor: pointer;
 
         &:hover {
-          background: var(--blue-700);
+          background: var(--blue-400);
         }
 
         &:focus-visible {

--- a/src/lib/components/profile/ProfileHero.svelte
+++ b/src/lib/components/profile/ProfileHero.svelte
@@ -1,9 +1,9 @@
 <script>
-  let { user, isEditing = false, formData, onFieldChange, avatarId, onAvatarUpload } = $props();
+  let { user, isEditMode = false, formData, draft = null, onFieldChange, avatarId, onAvatarUpload } = $props();
 
-  // Show live edited values, and fallback to saved user data when needed.
-  const profileName = $derived(formData?.name ?? user?.name ?? 'Unknown user');
-  const profession = $derived(formData?.profession ?? user?.profession ?? 'Unknown profession');
+  // Use `||` so empty formData (SSR / no-JS before $effect) still shows user.* ; `??` would keep "".
+  const profileName = $derived(formData?.name || user?.name || 'Unknown user');
+  const profession = $derived(formData?.profession || user?.profession || 'Unknown profession');
 
   // Build avatar URL from uploaded preview id or existing user photo id.
   const avatarSrc = $derived(
@@ -32,7 +32,7 @@
 <section class="profile-hero">
   <div class="avatar-wrap">
     <img class="profile-avatar" src={avatarSrc} alt={`Avatar of ${profileName}`} />
-    {#if isEditing}
+    {#if isEditMode}
       <button class="avatar-upload" type="button" onclick={openFilePicker}>Change photo</button>
       <input
         bind:this={fileInput}
@@ -44,23 +44,20 @@
     {/if}
   </div>
   <div class="profile-info">
-    {#if isEditing}
+    {#if isEditMode}
       <label class="sr-only" for="profile-name-input">Name</label>
       <input
         id="profile-name-input"
         class="name-input"
         type="text"
-        value={formData?.name ?? ''}
+        name="name"
+        value={formData?.name || draft?.name || user?.name || ''}
         oninput={(event) => onFieldChange?.('name', event.currentTarget.value)}
       />
-      <label class="sr-only" for="profile-profession-input">Profession</label>
-      <input
-        id="profile-profession-input"
-        class="profession-input"
-        type="text"
-        value={formData?.profession ?? ''}
-        oninput={(event) => onFieldChange?.('profession', event.currentTarget.value)}
-      />
+      <p class="profession-hero-note">
+        {formData?.profession || draft?.profession || user?.profession || '—'}
+      </p>
+      <span class="profession-hero-hint">Profession is edited under General information.</span>
     {:else}
       <h2>{profileName}</h2>
       <p>{profession}</p>
@@ -71,6 +68,8 @@
 <style>
   .profile-hero {
     display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
     justify-items: center;
     padding: 0 0 var(--spacing-lg);
 
@@ -134,9 +133,13 @@
     }
 
     .profile-info {
+      grid-column: 1;
+      grid-row: 2;
       margin-top: 3.5rem;
       text-align: center;
       padding-inline: var(--spacing-md);
+      position: relative;
+      z-index: 1;
 
       h2 {
         color: var(--blue-700);
@@ -147,8 +150,7 @@
         color: var(--grey-400);
       }
 
-      .name-input,
-      .profession-input {
+      .name-input {
         width: min(16rem, 90vw);
         margin: 0 auto;
         border: 2px solid var(--blue-500);
@@ -156,16 +158,22 @@
         padding: var(--spacing-xs) var(--spacing-sm);
         background: var(--blue-100);
         text-align: center;
-      }
-
-      .name-input {
         font-weight: 700;
         color: var(--blue-700);
       }
 
-      .profession-input {
+      .profession-hero-note {
         margin-top: var(--spacing-xs);
         color: var(--grey-500);
+        font-size: 1rem;
+      }
+
+      .profession-hero-hint {
+        display: block;
+        margin-top: 0.25rem;
+        font-size: 0.75rem;
+        color: var(--grey-400);
+        max-width: 18rem;
       }
     }
   }

--- a/src/lib/components/profile/ProfileHero.svelte
+++ b/src/lib/components/profile/ProfileHero.svelte
@@ -51,11 +51,11 @@
         class="name-input"
         type="text"
         name="name"
-        value={formData?.name || draft?.name || user?.name || ''}
+        value={formData?.name ?? draft?.name ?? user?.name ?? ''}
         oninput={(event) => onFieldChange?.('name', event.currentTarget.value)}
       />
       <p class="profession-hero-note">
-        {formData?.profession || draft?.profession || user?.profession || '—'}
+        {formData?.profession ?? draft?.profession ?? user?.profession ?? '—'}
       </p>
       <span class="profession-hero-hint">Profession is edited under General information.</span>
     {:else}

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -1,18 +1,26 @@
 <script>
-  let { isEditing = false, formData, onFieldChange } = $props();
+  /** Server snapshot for ?edit (SSR + first paint before client state syncs). */
+  let { user = null, isEditMode = false, formData, draft = null, onFieldChange } = $props();
+
+  function roleDisplay(profileUserRecord) {
+    if (!profileUserRecord?.role) return '';
+    return Array.isArray(profileUserRecord.role)
+      ? profileUserRecord.role.join(', ')
+      : String(profileUserRecord.role);
+  }
 </script>
 
-<section>
+<section class="profile-general-info">
   <h2>General Information</h2>
 
-  <form class="info-grid" aria-label="Profile details">
+  <div class="info-grid" role="group" aria-label="Profile details">
     <label for="info-role">
       <span>Role</span>
       <input
         id="info-role"
         type="text"
         readonly
-        value={formData?.role ?? ''}
+        value={formData?.role || roleDisplay(user)}
       />
     </label>
     <label for="info-institution">
@@ -20,8 +28,11 @@
       <input
         id="info-institution"
         type="text"
-        readonly={!isEditing}
-        value={formData?.institute ?? ''}
+        name={isEditMode ? 'institute' : undefined}
+        readonly={!isEditMode}
+        value={isEditMode
+          ? (formData?.institute || draft?.institute || user?.institute || '')
+          : (formData?.institute || user?.institute || '')}
         oninput={(event) => onFieldChange?.('institute', event.currentTarget.value)}
       />
     </label>
@@ -30,8 +41,11 @@
       <input
         id="info-profession"
         type="text"
-        readonly={!isEditing}
-        value={formData?.profession ?? ''}
+        name={isEditMode ? 'profession' : undefined}
+        readonly={!isEditMode}
+        value={isEditMode
+          ? (formData?.profession || draft?.profession || user?.profession || '')
+          : (formData?.profession || user?.profession || '')}
         oninput={(event) => onFieldChange?.('profession', event.currentTarget.value)}
       />
     </label>
@@ -40,16 +54,21 @@
       <input
         id="info-email"
         type="email"
-        readonly={!isEditing}
-        value={formData?.email ?? ''}
+        name={isEditMode ? 'email' : undefined}
+        readonly={!isEditMode}
+        value={isEditMode
+          ? (formData?.email || draft?.email || user?.email || '')
+          : (formData?.email || user?.email || '')}
         oninput={(event) => onFieldChange?.('email', event.currentTarget.value)}
       />
     </label>
-  </form>
+  </div>
 </section>
 
 <style>
-  section {
+  .profile-general-info {
+    position: relative;
+    z-index: 1;
     padding: 0 var(--spacing-md) var(--spacing-xl);
 
     h2 {
@@ -99,7 +118,7 @@
   }
 
   @container profile-card (min-width: 42rem) {
-    section {
+    .profile-general-info {
       padding: 0 var(--spacing-lg) var(--spacing-2xl);
 
       .info-grid {

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -20,7 +20,7 @@
         id="info-role"
         type="text"
         readonly
-        value={formData?.role || roleDisplay(user)}
+        value={formData?.role ?? roleDisplay(user)}
       />
     </label>
     <label for="info-institution">
@@ -31,8 +31,8 @@
         name={isEditMode ? 'institute' : undefined}
         readonly={!isEditMode}
         value={isEditMode
-          ? (formData?.institute || draft?.institute || user?.institute || '')
-          : (formData?.institute || user?.institute || '')}
+          ? (formData?.institute ?? draft?.institute ?? user?.institute ?? '')
+          : (formData?.institute ?? user?.institute ?? '')}
         oninput={(event) => onFieldChange?.('institute', event.currentTarget.value)}
       />
     </label>
@@ -44,8 +44,8 @@
         name={isEditMode ? 'profession' : undefined}
         readonly={!isEditMode}
         value={isEditMode
-          ? (formData?.profession || draft?.profession || user?.profession || '')
-          : (formData?.profession || user?.profession || '')}
+          ? (formData?.profession ?? draft?.profession ?? user?.profession ?? '')
+          : (formData?.profession ?? user?.profession ?? '')}
         oninput={(event) => onFieldChange?.('profession', event.currentTarget.value)}
       />
     </label>
@@ -57,8 +57,8 @@
         name={isEditMode ? 'email' : undefined}
         readonly={!isEditMode}
         value={isEditMode
-          ? (formData?.email || draft?.email || user?.email || '')
-          : (formData?.email || user?.email || '')}
+          ? (formData?.email ?? draft?.email ?? user?.email ?? '')
+          : (formData?.email ?? user?.email ?? '')}
         oninput={(event) => onFieldChange?.('email', event.currentTarget.value)}
       />
     </label>

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -101,12 +101,8 @@ export const actions = {
     }
 
     const photoRaw = form.get('photo')
-    if (typeof photoRaw === 'string' && photoRaw.startsWith('data:image/')) {
-      const photoId = await uploadDataUrlToDirectusFile(photoRaw, fetch)
-      if (!photoId) {
-        return fail(400, { message: 'Could not save profile photo' })
-      }
-      corePayload.photo = photoId
+    if (typeof photoRaw === 'string' && photoRaw.trim()) {
+      corePayload.photo = photoRaw.trim()
     }
 
     // Update the input fields in Directus.
@@ -135,5 +131,34 @@ export const actions = {
       throw redirect(303, `/profile?saved=1&warning=${encodeURIComponent(warn)}`)
     }
     throw redirect(303, '/profile?saved=1')
+  },
+
+  uploadAvatar: async ({ request, fetch, locals }) => {
+    const sessionUser = locals.user
+    if (!sessionUser) return { ok: false, message: 'Unauthorized' }
+    if (!DIRECTUS_TOKEN) return { ok: false, message: 'Server config missing' }
+
+    const form = await request.formData().catch(() => null)
+    const avatar = form?.get('avatar')
+    if (!(avatar instanceof File)) return { ok: false, message: 'No avatar file uploaded' }
+
+    const uploadBody = new FormData()
+    uploadBody.append('file', avatar)
+    const uploadResponse = await fetch(`${DIRECTUS_URL}/files`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${DIRECTUS_TOKEN}` },
+      body: uploadBody
+    })
+
+    if (!uploadResponse.ok) {
+      const details = await uploadResponse.text().catch(() => '')
+      return { ok: false, message: 'Avatar upload failed', details }
+    }
+
+    const uploadData = await uploadResponse.json().catch(() => null)
+    const photoId = uploadData?.data?.id
+    if (!photoId) return { ok: false, message: 'Upload succeeded but file id missing' }
+
+    return { ok: true, photo: photoId }
   }
 }

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -100,7 +100,16 @@ export const actions = {
       profession: String(profession).trim()
     }
 
-    // Update main fields in Directus.
+    const photoRaw = form.get('photo')
+    if (typeof photoRaw === 'string' && photoRaw.startsWith('data:image/')) {
+      const photoId = await uploadDataUrlToDirectusFile(photoRaw, fetch)
+      if (!photoId) {
+        return fail(400, { message: 'Could not save profile photo' })
+      }
+      corePayload.photo = photoId
+    }
+
+    // Update the input fields in Directus.
     const updateResponse = await patchUser({ fetch, userId, payload: corePayload })
     if (!updateResponse.ok) {
       const details = await updateResponse.text().catch(() => '')
@@ -126,52 +135,5 @@ export const actions = {
       throw redirect(303, `/profile?saved=1&warning=${encodeURIComponent(warn)}`)
     }
     throw redirect(303, '/profile?saved=1')
-  },
-
-  // This action upload avatar photo file.
-  // Called from: /profile?/uploadAvatar
-  uploadAvatar: async ({ request, fetch, locals }) => {
-    const sessionUser = locals.user
-    // Must be logged in.
-    if (!sessionUser) return { ok: false, message: 'Unauthorized' }
-    // Token must exist on server.
-    if (!DIRECTUS_TOKEN) return { ok: false, message: 'Server config missing' }
-
-    // I use session user id for secure update.
-    const userId = sessionUser.id
-    if (!userId) return { ok: false, message: 'Could not resolve user id for update' }
-
-    // Read form-data and get uploaded avatar file.
-    const form = await request.formData().catch(() => null)
-    const avatar = form?.get('avatar')
-    if (!(avatar instanceof File)) return { ok: false, message: 'No avatar file uploaded' }
-
-    // Upload file first to Directus files endpoint.
-    const uploadBody = new FormData()
-    uploadBody.append('file', avatar)
-    const uploadResponse = await fetch(`${DIRECTUS_URL}/files`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${DIRECTUS_TOKEN}` },
-      body: uploadBody
-    })
-
-    if (!uploadResponse.ok) {
-      const details = await uploadResponse.text().catch(() => '')
-      return { ok: false, message: 'Avatar upload failed', details }
-    }
-
-    const uploadData = await uploadResponse.json().catch(() => null)
-    const photoId = uploadData?.data?.id
-    if (!photoId) return { ok: false, message: 'Upload succeeded but file id missing' }
-
-    // Then save returned file id into user photo field.
-    const photoResponse = await patchUser({ fetch, userId, payload: { photo: photoId } })
-    if (!photoResponse.ok) {
-      const details = await photoResponse.text().catch(() => '')
-      return { ok: false, message: 'Avatar uploaded but profile photo update failed', details }
-    }
-
-    // Return photo id so frontend can show new image directly.
-    return { ok: true, photo: photoId }
   }
 }

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -1,5 +1,16 @@
+import { fail, redirect } from '@sveltejs/kit'
 import { env } from '$env/dynamic/public'
 import { env as privateEnv } from '$env/dynamic/private'
+
+function formFieldsFromUser(sourceUser = {}) {
+  return {
+    name: sourceUser?.name ?? '',
+    role: Array.isArray(sourceUser?.role) ? sourceUser.role.join(', ') : (sourceUser?.role ?? ''),
+    institute: sourceUser?.institute ?? '',
+    profession: sourceUser?.profession ?? '',
+    email: sourceUser?.email ?? ''
+  }
+}
 
 // This is my Directus base url.
 const DIRECTUS_URL = env.PUBLIC_DIRECTUS_URL || 'https://fdnd-agency.directus.app'
@@ -9,8 +20,11 @@ const DIRECTUS_TOKEN = privateEnv.DIRECTUS_TOKEN
 // This load run when profile page open.
 // Here i get current user data from Directus by email,
 // so page show real latest profile info.
-export async function load({ fetch, locals }) {
+export async function load({ fetch, locals, url }) {
   const sessionUser = locals.user
+  const isEditMode = url.searchParams.has('edit')
+  const saved = url.searchParams.get('saved') === '1'
+  const saveWarning = url.searchParams.get('warning') ?? ''
 
   // Get user by exact email from session.
   const usersResponse = await fetch(
@@ -20,15 +34,29 @@ export async function load({ fetch, locals }) {
 
   // If request fail, i fallback to session user.
   if (!usersResponse.ok) {
-    return { user: sessionUser }
+    const user = sessionUser
+    return {
+      user,
+      isEditMode,
+      saved,
+      saveWarning,
+      ...(isEditMode ? { editForm: formFieldsFromUser(user) } : {})
+    }
   }
 
   // Directus return user list in data array.
   const usersResult = await usersResponse.json()
   const [user] = usersResult?.data ?? []
+  const resolvedUser = user ?? sessionUser
 
   // If user found use it, else use session user.
-  return { user: user ?? sessionUser }
+  return {
+    user: resolvedUser,
+    isEditMode,
+    saved,
+    saveWarning,
+    ...(isEditMode ? { editForm: formFieldsFromUser(resolvedUser) } : {})
+  }
 }
 
 // Small helper so i can PATCH user fields without repeating same code.
@@ -48,17 +76,17 @@ export const actions = {
   saveProfile: async ({ request, fetch, locals }) => {
     const sessionUser = locals.user
     // Must be logged in.
-    if (!sessionUser) return { ok: false, message: 'Unauthorized' }
+    if (!sessionUser) return fail(401, { message: 'Unauthorized' })
     // Token must exist on server.
-    if (!DIRECTUS_TOKEN) return { ok: false, message: 'Server config missing' }
+    if (!DIRECTUS_TOKEN) return fail(500, { message: 'Server config missing' })
 
     // Read JSON body from frontend.
     const form = await request.formData().catch(() => null)
-    if (!form) return { ok: false, message: 'Invalid request body' }
+    if (!form) return fail(400, { message: 'Invalid request body' })
 
     // I use session user id for secure update.
     const userId = sessionUser.id
-    if (!userId) return { ok: false, message: 'Could not resolve user id for update' }
+    if (!userId) return fail(400, { message: 'Could not resolve user id for update' })
 
     // Fields that can be edited in profile form.
     const name = String(form.get('name') ?? '')
@@ -76,7 +104,7 @@ export const actions = {
     const updateResponse = await patchUser({ fetch, userId, payload: corePayload })
     if (!updateResponse.ok) {
       const details = await updateResponse.text().catch(() => '')
-      return { ok: false, message: 'Failed to save core profile fields', details }
+      return fail(400, { message: 'Failed to save core profile fields', details })
     }
 
     // Optional warnings list (for non blocking fields).
@@ -91,9 +119,13 @@ export const actions = {
       if (!emailResponse.ok) warnings.push('Email could not be updated')
     }
 
-    // Return success response to frontend.
-    const result = await updateResponse.json().catch(() => ({}))
-    return { ok: true, data: result?.data ?? corePayload, warnings }
+    await updateResponse.json().catch(() => ({}))
+
+    const warn = warnings[0]
+    if (warn) {
+      throw redirect(303, `/profile?saved=1&warning=${encodeURIComponent(warn)}`)
+    }
+    throw redirect(303, '/profile?saved=1')
   },
 
   // This action upload avatar photo file.

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   import { browser } from '$app/environment'
-  import { deserialize, enhance } from '$app/forms'
-  import { goto, invalidateAll } from '$app/navigation'
+  import { enhance } from '$app/forms'
+  import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
   import GroupsLink from '$lib/components/profile/GroupsLink.svelte'
   import EditActions from '$lib/components/profile/EditActions.svelte'
@@ -15,6 +15,28 @@
       institute: sourceUser?.institute ?? '',
       profession: sourceUser?.profession ?? '',
       email: sourceUser?.email ?? ''
+    }
+  }
+
+  const AVATAR_MAX_EDGE = 800
+  const AVATAR_JPEG_QUALITY = 0.82
+
+  async function resizeImageFileToDataUrl(file) {
+    const bitmap = await createImageBitmap(file)
+    try {
+      const { width, height } = bitmap
+      const scale = Math.min(1, AVATAR_MAX_EDGE / Math.max(width, height))
+      const w = Math.max(1, Math.round(width * scale))
+      const h = Math.max(1, Math.round(height * scale))
+      const canvas = document.createElement('canvas')
+      canvas.width = w
+      canvas.height = h
+      const ctx = canvas.getContext('2d')
+      if (!ctx) throw new Error('Canvas not available')
+      ctx.drawImage(bitmap, 0, 0, w, h)
+      return canvas.toDataURL('image/jpeg', AVATAR_JPEG_QUALITY)
+    } finally {
+      bitmap.close()
     }
   }
 
@@ -48,11 +70,12 @@
 
     if (isEditMode && data.editForm) {
       formData = { ...data.editForm }
+      currentAvatarId = null
       return
     }
 
     syncFormDataFromProfile(profileUser)
-    if (profileUser.photo) currentAvatarId = profileUser.photo
+    currentAvatarId = null
   })
 
   /** Hide save banner after 10s by dropping `saved` / `warning` from the URL (client only). */
@@ -70,37 +93,13 @@
     formData = { ...formData, [field]: value }
   }
 
-  function parseAvatarActionResponse(responseBodyText) {
-    const actionResult = deserialize(responseBodyText)
-    if (actionResult.type === 'success') return actionResult.data
-    if (actionResult.type === 'failure') return actionResult.data
-    return null
-  }
-
   async function uploadAvatar(imageFile) {
-    if (isUploadingAvatar || !imageFile) return
+    if (!browser || isUploadingAvatar || !imageFile) return
     isUploadingAvatar = true
-
     try {
-      const multipartBody = new FormData()
-      multipartBody.append('avatar', imageFile)
-
-      const uploadResponse = await fetch('/profile?/uploadAvatar', {
-        method: 'POST',
-        headers: { accept: 'application/json' },
-        body: multipartBody
-      })
-
-      const uploadResult = parseAvatarActionResponse(await uploadResponse.text())
-      if (!uploadResult?.ok || !uploadResult?.photo) {
-        showTransientToast(uploadResult?.message || 'Could not upload profile photo')
-        return
-      }
-
-      currentAvatarId = uploadResult.photo
-      if (!isEditMode) await invalidateAll()
+      currentAvatarId = await resizeImageFileToDataUrl(imageFile)
     } catch {
-      showTransientToast('Could not upload profile photo')
+      showTransientToast('Could not process profile photo')
     } finally {
       isUploadingAvatar = false
     }
@@ -139,6 +138,7 @@
         }}
       >
         <EditActions isEditMode={true} formId="profile-edit-form" disabled={savePending} />
+        <input type="hidden" name="photo" value={currentAvatarId ?? ''} />
         <div class="profile-body">
           <ProfileHero
             user={profileUser}
@@ -167,7 +167,7 @@
           {formData}
           draft={null}
           {onFieldChange}
-          avatarId={currentAvatarId}
+          avatarId={null}
           onAvatarUpload={uploadAvatar}
         />
         <ProfileInfo user={profileUser} isEditMode={false} {formData} draft={null} {onFieldChange} />

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,176 +1,178 @@
 <script>
-  import { deserialize } from '$app/forms'
+  import { browser } from '$app/environment'
+  import { deserialize, enhance } from '$app/forms'
+  import { goto, invalidateAll } from '$app/navigation'
+  import { resolve } from '$app/paths'
   import GroupsLink from '$lib/components/profile/GroupsLink.svelte'
   import EditActions from '$lib/components/profile/EditActions.svelte'
-  import ProfileHero from "$lib/components/profile/ProfileHero.svelte";
-  import ProfileInfo from "$lib/components/profile/ProfileInfo.svelte";
-  let { data } = $props();
-  const user = $derived(data.user);
+  import ProfileHero from '$lib/components/profile/ProfileHero.svelte'
+  import ProfileInfo from '$lib/components/profile/ProfileInfo.svelte'
 
-  // Build a safe UI model from the user object (prevents undefined values in inputs).
-  const createFormData = (sourceUser = {}) => ({
-    name: sourceUser?.name ?? '',
-    role: Array.isArray(sourceUser?.role) ? sourceUser.role.join(', ') : (sourceUser?.role ?? ''),
-    institute: sourceUser?.institute ?? '',
-    profession: sourceUser?.profession ?? '',
-    email: sourceUser?.email ?? ''
-  });
-
-  // UI mode flags for edit/save/avatar-upload actions.
-  let isEditing = $state(false);
-  let isSaving = $state(false);
-  let isUploadingAvatar = $state(false);
-  // Last saved values and currently edited values.
-  let savedProfile = $state(createFormData());
-  let formData = $state(createFormData());
-  // Local avatar id so uploaded photo appears immediately.
-  let currentAvatarId = $state(null);
-  // Toast state and timer for temporary feedback messages.
-  let toastMessage = $state('');
-  let toastTimer;
-
-  // Sync local editable state from a user source.
-  function resetFromUser(sourceUser) {
-    const nextData = createFormData(sourceUser);
-    savedProfile = { ...nextData };
-    formData = { ...nextData };
+  function formFieldsFromUser(sourceUser = {}) {
+    return {
+      name: sourceUser?.name ?? '',
+      role: Array.isArray(sourceUser?.role) ? sourceUser.role.join(', ') : (sourceUser?.role ?? ''),
+      institute: sourceUser?.institute ?? '',
+      profession: sourceUser?.profession ?? '',
+      email: sourceUser?.email ?? ''
+    }
   }
 
-  // Initialize profile state once user data is available.
-  $effect(() => {
-    if (!savedProfile.email && user) {
-      resetFromUser(user);
-    }
-    if (!currentAvatarId && user?.photo) {
-      currentAvatarId = user.photo;
-    }
-  });
+  let { data, form } = $props()
 
-  // Update one field in the editable form state.
-  function onFieldChange(field, value) {
-    formData = { ...formData, [field]: value };
-  }
+  const profileUser = $derived(data.user)
+  const isEditMode = $derived(data.isEditMode)
+  const editFormDefaults = $derived(data.editForm ?? null)
 
-  // Show temporary feedback at the bottom of the page.
-  function showToast(message) {
-    toastMessage = message;
-    clearTimeout(toastTimer);
+  let savePending = $state(false)
+  let isUploadingAvatar = $state(false)
+  let formData = $state(formFieldsFromUser())
+  let currentAvatarId = $state(null)
+  let toastMessage = $state('')
+  let toastTimer
+
+  function showTransientToast(text) {
+    toastMessage = text
+    clearTimeout(toastTimer)
     toastTimer = setTimeout(() => {
-      toastMessage = '';
-    }, 2200);
+      toastMessage = ''
+    }, 2200)
   }
 
-  function parseActionResponse(responseText) {
-    const result = deserialize(responseText);
-    if (result.type === 'success') return result.data;
-    if (result.type === 'failure') return result.data;
-    return null;
+  function syncFormDataFromProfile(profileUserRecord) {
+    formData = { ...formFieldsFromUser(profileUserRecord) }
   }
 
-  // Enter edit mode and restore draft from last saved profile.
-  function startEdit() {
-    formData = { ...savedProfile };
-    isEditing = true;
-  }
+  $effect(() => {
+    if (!profileUser) return
 
-  // Exit edit mode without persisting changes.
-  function cancelEdit() {
-    formData = { ...savedProfile };
-    isEditing = false;
-    showToast('Editing cancelled');
-  }
-
-  // Persist profile fields to server and keep local state in sync.
-  async function saveEdit() {
-    if (isSaving) return;
-    isSaving = true;
-
-    try {
-      const body = new URLSearchParams({
-        name: formData.name ?? '',
-        institute: formData.institute ?? '',
-        profession: formData.profession ?? '',
-        email: formData.email ?? ''
-      });
-
-      const response = await fetch('/profile?/saveProfile', {
-        method: 'POST',
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/x-www-form-urlencoded'
-        },
-        body
-      });
-
-      const result = parseActionResponse(await response.text());
-      if (!result?.ok) {
-        showToast(result?.message || 'Could not save profile');
-        return;
-      }
-
-      savedProfile = { ...formData };
-      isEditing = false;
-      if (result?.warnings?.length) {
-        showToast(`Saved with warning: ${result.warnings[0]}`);
-        return;
-      }
-
-      showToast('Profile changes saved');
-    } catch {
-      showToast('Could not save profile');
-    } finally {
-      isSaving = false;
+    if (isEditMode && data.editForm) {
+      formData = { ...data.editForm }
+      return
     }
+
+    syncFormDataFromProfile(profileUser)
+    if (profileUser.photo) currentAvatarId = profileUser.photo
+  })
+
+  /** Hide save banner after 10s by dropping `saved` / `warning` from the URL (client only). */
+  $effect(() => {
+    if (!browser || !data.saved) return
+
+    const hideBannerTimer = setTimeout(() => {
+      goto(resolve('/profile'), { replaceState: true, noScroll: true })
+    }, 10_000)
+
+    return () => clearTimeout(hideBannerTimer)
+  })
+
+  function onFieldChange(field, value) {
+    formData = { ...formData, [field]: value }
   }
 
-  // Upload avatar through the same /profile endpoint.
-  async function uploadAvatar(file) {
-    if (isUploadingAvatar || !file) return;
-    isUploadingAvatar = true;
+  function parseAvatarActionResponse(responseBodyText) {
+    const actionResult = deserialize(responseBodyText)
+    if (actionResult.type === 'success') return actionResult.data
+    if (actionResult.type === 'failure') return actionResult.data
+    return null
+  }
+
+  async function uploadAvatar(imageFile) {
+    if (isUploadingAvatar || !imageFile) return
+    isUploadingAvatar = true
 
     try {
-      const payload = new FormData();
-      payload.append('avatar', file);
+      const multipartBody = new FormData()
+      multipartBody.append('avatar', imageFile)
 
-      const response = await fetch('/profile?/uploadAvatar', {
+      const uploadResponse = await fetch('/profile?/uploadAvatar', {
         method: 'POST',
         headers: { accept: 'application/json' },
-        body: payload
-      });
+        body: multipartBody
+      })
 
-      const result = parseActionResponse(await response.text());
-      if (!result?.ok || !result?.photo) {
-        showToast(result?.message || 'Could not upload profile photo');
-        return;
+      const uploadResult = parseAvatarActionResponse(await uploadResponse.text())
+      if (!uploadResult?.ok || !uploadResult?.photo) {
+        showTransientToast(uploadResult?.message || 'Could not upload profile photo')
+        return
       }
 
-      currentAvatarId = result.photo;
-      showToast('Profile photo updated');
+      currentAvatarId = uploadResult.photo
+      if (!isEditMode) await invalidateAll()
     } catch {
-      showToast('Could not upload profile photo');
+      showTransientToast('Could not upload profile photo')
     } finally {
-      isUploadingAvatar = false;
+      isUploadingAvatar = false
     }
   }
-
 </script>
-
-
 
 <section class="profile-page">
   <h1 class="profile-title">Profile</h1>
 
+  {#if form?.message}
+    <p class="form-error" role="alert">{form.message}</p>
+  {/if}
+
+  {#if data.saved}
+    <p class="save-banner" role="status">
+      Profile changes saved.
+      {#if data.saveWarning}
+        {data.saveWarning}
+      {/if}
+    </p>
+  {/if}
+
   <article class="profile-card">
-    <EditActions {isEditing} disabled={isSaving} onStartEdit={startEdit} onSave={saveEdit} onCancel={cancelEdit} />
-    <ProfileHero
-      {user}
-      {isEditing}
-      {formData}
-      {onFieldChange}
-      avatarId={currentAvatarId}
-      onAvatarUpload={uploadAvatar}
-    />
-    <ProfileInfo {isEditing} {formData} {onFieldChange} />
+    {#if isEditMode}
+      <form
+        id="profile-edit-form"
+        class="profile-edit-form"
+        method="POST"
+        action="?/saveProfile"
+        use:enhance={() => {
+          savePending = true
+          return async ({ update }) => {
+            await update()
+            savePending = false
+          }
+        }}
+      >
+        <EditActions isEditMode={true} formId="profile-edit-form" disabled={savePending} />
+        <div class="profile-body">
+          <ProfileHero
+            user={profileUser}
+            isEditMode={true}
+            {formData}
+            draft={editFormDefaults}
+            {onFieldChange}
+            avatarId={currentAvatarId}
+            onAvatarUpload={uploadAvatar}
+          />
+          <ProfileInfo
+            user={profileUser}
+            isEditMode={true}
+            {formData}
+            draft={editFormDefaults}
+            {onFieldChange}
+          />
+        </div>
+      </form>
+    {:else}
+      <EditActions isEditMode={false} />
+      <div class="profile-body">
+        <ProfileHero
+          user={profileUser}
+          isEditMode={false}
+          {formData}
+          draft={null}
+          {onFieldChange}
+          avatarId={currentAvatarId}
+          onAvatarUpload={uploadAvatar}
+        />
+        <ProfileInfo user={profileUser} isEditMode={false} {formData} draft={null} {onFieldChange} />
+      </div>
+    {/if}
     <GroupsLink />
   </article>
 
@@ -190,14 +192,43 @@
       margin-bottom: var(--spacing-md);
     }
 
+    .form-error {
+      max-width: 42rem;
+      margin: 0 auto var(--spacing-md);
+      padding: var(--spacing-sm) var(--spacing-md);
+      border-radius: var(--radius-sm);
+      background: var(--red-100);
+      color: var(--red-700);
+    }
+
+    .save-banner {
+      max-width: 42rem;
+      margin: 0 auto var(--spacing-md);
+      padding: var(--spacing-sm) var(--spacing-md);
+      border-radius: var(--radius-sm);
+      background: var(--blue-100);
+      color: var(--blue-700);
+    }
+
     .profile-card {
       position: relative;
       background: var(--background-color-primary);
       border-radius: var(--radius-lg);
       box-shadow: var(--shadow-sm);
-      overflow: hidden;
+      overflow: visible;
       container-type: inline-size;
       container-name: profile-card;
+    }
+
+    .profile-edit-form {
+      margin: 0;
+      padding: 0;
+      border: none;
+    }
+
+    .profile-body {
+      display: flow-root;
+      min-width: 0;
     }
 
     .toast {

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,6 +1,6 @@
 <script>
   import { browser } from '$app/environment'
-  import { enhance } from '$app/forms'
+  import { deserialize, enhance } from '$app/forms'
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
   import GroupsLink from '$lib/components/profile/GroupsLink.svelte'
@@ -15,28 +15,6 @@
       institute: sourceUser?.institute ?? '',
       profession: sourceUser?.profession ?? '',
       email: sourceUser?.email ?? ''
-    }
-  }
-
-  const AVATAR_MAX_EDGE = 800
-  const AVATAR_JPEG_QUALITY = 0.82
-
-  async function resizeImageFileToDataUrl(file) {
-    const bitmap = await createImageBitmap(file)
-    try {
-      const { width, height } = bitmap
-      const scale = Math.min(1, AVATAR_MAX_EDGE / Math.max(width, height))
-      const w = Math.max(1, Math.round(width * scale))
-      const h = Math.max(1, Math.round(height * scale))
-      const canvas = document.createElement('canvas')
-      canvas.width = w
-      canvas.height = h
-      const ctx = canvas.getContext('2d')
-      if (!ctx) throw new Error('Canvas not available')
-      ctx.drawImage(bitmap, 0, 0, w, h)
-      return canvas.toDataURL('image/jpeg', AVATAR_JPEG_QUALITY)
-    } finally {
-      bitmap.close()
     }
   }
 
@@ -93,13 +71,35 @@
     formData = { ...formData, [field]: value }
   }
 
+  function parseAvatarActionResponse(responseBodyText) {
+    const actionResult = deserialize(responseBodyText)
+    if (actionResult.type === 'success') return actionResult.data
+    if (actionResult.type === 'failure') return actionResult.data
+    return null
+  }
+
   async function uploadAvatar(imageFile) {
     if (!browser || isUploadingAvatar || !imageFile) return
     isUploadingAvatar = true
     try {
-      currentAvatarId = await resizeImageFileToDataUrl(imageFile)
+      const multipartBody = new FormData()
+      multipartBody.append('avatar', imageFile)
+
+      const uploadResponse = await fetch('/profile?/uploadAvatar', {
+        method: 'POST',
+        headers: { accept: 'application/json' },
+        body: multipartBody
+      })
+
+      const uploadResult = parseAvatarActionResponse(await uploadResponse.text())
+      if (!uploadResult?.ok || !uploadResult?.photo) {
+        showTransientToast(uploadResult?.message || 'Could not upload profile photo')
+        return
+      }
+
+      currentAvatarId = uploadResult.photo
     } catch {
-      showTransientToast('Could not process profile photo')
+      showTransientToast('Could not upload profile photo')
     } finally {
       isUploadingAvatar = false
     }


### PR DESCRIPTION
## What does this change?

Resolves issue #334 

Replaces the client-side JS edit flow (isEditing state, manual fetch, callback props) with a URL driven approach using ?edit search params and native SvelteKit form actions. 
Edit state is now fully serverrendered 



## How Has This Been Tested?
<!-- Link to test results in the Wiki-->
[LInk to wiki test ](https://github.com/fdnd-agency/footguard/wiki/Profile-page-RAPPE)

- [x] [User test]()
- [x] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images

<img width="337" height="708" alt="Screenshot 2026-04-12 at 22 08 45" src="https://github.com/user-attachments/assets/efd4e405-db4c-4a73-a1d7-a7516180ffeb" />



## How to review

Run this branch locally.
Go to the profile page, click edit, change any field (name, institute, profession, email) and hit save.
it should save correctly.
Try uploading a profile pic it should also should work.
Try to turn off JS also everything should work fine.
