### PR TITLE
336 user story group members list

### DIFF
--- a/src/lib/assets/svg/SwitchSidesIcon.svelte
+++ b/src/lib/assets/svg/SwitchSidesIcon.svelte
@@ -1,0 +1,21 @@
+<script>
+  export let width = 19;
+  export let height = 19;
+</script>
+
+<svg
+  {width}
+  {height}
+  viewBox="0 0 19 19"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path
+    d="M4.60448 17.0999L1.90002 14.2499M1.90002 14.2499L4.60448 11.3999M1.90002 14.2499H15.2C16.2494 14.2499 17.1 13.3992 17.1 12.3499V9.4999M14.3956 1.8999L17.1 4.7499M17.1 4.7499L14.3956 7.5999M17.1 4.7499L3.80002 4.7499C2.75068 4.7499 1.90002 5.60056 1.90002 6.6499L1.90002 9.4999"
+  />
+</svg>

--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -1,8 +1,4 @@
 <script>
-  /*
-   * SwitchSidesButton uses `onclick`; GroupMemberCard uses `onBack` to return to the front.
-   */
-  import { browser } from "$app/environment";
   import DetailsUpIcon from "$lib/assets/svg/DetailsUpIcon.svelte";
   import GroupCardHeader from "$lib/components/groups/GroupCardHeader.svelte";
   import GroupInviteForm from "$lib/components/groups/GroupInviteForm.svelte";
@@ -11,100 +7,134 @@
   import UserSectionDropdown from "$lib/components/groups/UserSectionDropdown.svelte";
   import previewAvatarFallback from "$lib/assets/img/profile-avatar.webp";
 
-  // Group data is passed from the groups page
-  export let group;
-  export let form; // Form action result passed down from +page.svelte for invite form feedback
+  // Group data is passed from the groups page; `form` is invite action feedback from +page.svelte
+  let { group, form } = $props();
 
-  // Fallback values keep the component safe while API data is still incomplete
-  $: groupId = group?.id;
-  $: groupName = group?.name ?? "Unnamed group";
-  $: groupStatus = group?.status ?? "Unknown";
-  $: conditionLabel = group?.conditionlabel ?? "General";
+  let flipped = $state(false);
 
-// Members array from group data — now populated from footguard_group_members
-  $: members = group?.members ?? [];
-  $: memberCount = members.length > 0 ? members.length : (group?.memberCount ?? 0);
+  function flipToMembers() {
+    flipped = true;
+  }
 
-  const groupId = $derived(group?.id ?? "");
-  const frontFaceId = $derived(`group-${groupId}`);
-  const membersFaceId = $derived(`group-${groupId}-members`);
+  function flipToFront() {
+    flipped = false;
+  }
 
- // Max number of member avatars to show in the preview
+  // Max number of member avatars to show in the preview
   const MAX_PREVIEW_MEMBERS = 2;
 
-  // Reactive plural check to avoid magic numbers in the template
-  $: isPlural = memberCount !== 1;
+  // Fallback values keep the component safe while API data is still incomplete
+  const groupId = $derived(group?.id ?? "");
+  const groupName = $derived(group?.name ?? "Unnamed group");
+  const groupStatus = $derived(group?.status ?? "Unknown");
+  const conditionLabel = $derived(group?.conditionlabel ?? "General");
 
-  // Create temporary preview items with stable ids for rendering
-  $: previewMembers =
-     memberCount > 0
+  // Members array from group data — now populated from footguard_group_members
+  const members = $derived(group?.members ?? []);
+  const memberCount = $derived(
+    members.length > 0 ? members.length : (group?.memberCount ?? 0)
+  );
+
+  const faceIdSuffix = $derived(String(group?.id ?? "unknown"));
+  const frontFaceId = $derived(`group-${faceIdSuffix}`);
+  const membersFaceId = $derived(`group-${faceIdSuffix}-members`);
+
+  const membersForBackFace = $derived(
+    members.map((m) => ({
+      id: m.id,
+      name: m.name,
+      role: m.role,
+      avatarUrl: m.avatarUrl ?? previewAvatarFallback
+    }))
+  );
+
+  const isPlural = $derived(memberCount !== 1);
+
+  const previewMembers = $derived(
+    memberCount > 0
       ? Array.from({ length: Math.min(memberCount, MAX_PREVIEW_MEMBERS) }, (_, index) => ({
           id: index + 1,
-          // Use the real member name if available
           name: members[index]?.name ?? null
         }))
-      : [];
+      : []
+  );
 </script>
 
-<article>
-  <GroupCardHeader
-  name={groupName}
-  status={groupStatus}
-  conditionLabel={conditionLabel}
-/>
+<article class="group-card-root">
+  <div class="scene">
+    <div class="flipper" class:flipped={flipped}>
+      <!-- Front: summary + invite + details -->
+      <div class="face face--front" id={frontFaceId}>
+        <div class="group-card-header">
+          <GroupCardHeader
+            name={groupName}
+            status={groupStatus}
+            conditionLabel={conditionLabel}
+          />
+          <SwitchSidesButton label="Members" onclick={flipToMembers} />
+        </div>
 
-<section class="members-section">
-    <h2 class="title">Members</h2>
+        <section class="members-section">
+          <h2 class="title">Members</h2>
 
-    <!-- Member avatar preview row with add button -->
-    <div class="members-preview">
-      {#if previewMembers.length > 0}
-        <ul aria-label="Current members preview">
-          {#each previewMembers as member (member.id)}
-            <li>
-              <!-- Avatar image is managed via Directus, no changes needed here -->
-              <img src={avatar} alt={member.name ?? `Group member ${member.id}`} />
-            </li>
-          {/each}
-        </ul>
-      {/if}
+          <!-- Member avatar preview row with add button -->
+          <div class="members-preview">
+            {#if previewMembers.length > 0}
+              <ul aria-label="Current members preview">
+                {#each previewMembers as member (member.id)}
+                  <li>
+                    <img
+                      class="members-preview-av"
+                      src={previewAvatarFallback}
+                      alt={member.name ?? `Group member ${member.id}`}
+                    />
+                  </li>
+                {/each}
+              </ul>
+            {/if}
 
-  <!-- Dashed circle add button next to avatars -->
-<button class="btn-add" type="button" aria-label="Add team member">
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-    <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
-  </svg>
-</button>
+            <!-- Dashed circle add button next to avatars -->
+            <button class="btn-add" type="button" aria-label="Add team member">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+              </svg>
+            </button>
+          </div>
+
+          {#if previewMembers.length === 0}
+            <p class="members-empty">No members available yet.</p>
+          {/if}
+
+          <GroupInviteForm {groupId} {members} {form} />
+        </section>
+
+        <details>
+          <summary>
+            <span>{memberCount} member{isPlural ? "s" : ""}</span>
+            <span class="chevron">
+              <DetailsUpIcon />
+            </span>
+          </summary>
+          <UserSectionDropdown {members} />
+        </details>
+      </div>
+
+      <!-- Back: full member list -->
+      <div class="face face--back" id={membersFaceId}>
+        <GroupMemberCard
+          {groupId}
+          {groupName}
+          members={membersForBackFace}
+          onBack={flipToFront}
+        />
+      </div>
     </div>
-
-    {#if previewMembers.length === 0}
-      <!-- Empty state: shown when group has no members yet -->
-      <p class="members-empty">No members available yet.</p>
-    {/if}
-
-    <!--
-      GroupInviteForm handles adding existing Directus users by email.
-      Passes members so the form can show the current member list locally.
-      Passes form for server action result feedback per group.
-    -->
-    <GroupInviteForm
-      groupId={groupId}
-      members={members}
-      {form}
-    />
-  </section>
-
-  <!-- Expandable dropdown showing the full member list with details -->
-  <details>
-    <summary>
-      <span>{memberCount} member{isPlural ? 's' : ''}</span>
-      <span class="chevron">
-        <DetailsUpIcon />
-      </span>
-    </summary>
-    <!-- Pass members array down to the dropdown component -->
-<UserSectionDropdown {members} />
-  </details>
+  </div>
 </article>
 
 <style>
@@ -150,6 +180,7 @@
 
   .group-card-header {
     position: relative;
+    flex-shrink: 0;
 
     & :global(.switch-sides-btn) {
       position: absolute;
@@ -159,7 +190,7 @@
     }
   }
 
-    .members-preview {
+  .members-preview {
     display: flex;
     align-items: center;
     gap: var(--spacing-xs);
@@ -169,6 +200,28 @@
       margin: 0;
       padding: 0;
       list-style: none;
+    }
+
+    .btn-add {
+      width: 3rem;
+      height: 3rem;
+      border-radius: var(--radius-full);
+      border: 2px dashed var(--grey-300);
+      background: transparent;
+      color: var(--grey-400);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      transition:
+        border-color var(--transition-fast),
+        color var(--transition-fast);
+      flex-shrink: 0;
+
+      svg {
+        width: 1.25rem;
+        height: 1.25rem;
+      }
     }
   }
 
@@ -224,48 +277,13 @@
         }
       }
     }
-
-    /* Dashed circle add button next to avatars */
-  .btn-add {
-    width: 3rem;
-    height: 3rem;
-    border-radius: var(--radius-full);
-    border: 2px dashed var(--grey-300);
-    background: transparent;
-    color: var(--grey-400);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    transition: border-color var(--transition-fast), color var(--transition-fast);
-    flex-shrink: 0;
-
-    svg {
-    width: 1.25rem;
-    height: 1.25rem;
-
-    }
   }
 
   .members-section {
+    flex: 1;
+    min-height: 0;
     padding: var(--spacing-lg);
-  }
-
-  summary {
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: var(--spacing-md) var(--spacing-lg);
-    border-top: 1px solid var(--grey-100);
-    background: var(--grey-50);
-    color: var(--grey-600);
-    list-style: none;
-    cursor: pointer;
-
-    &::-webkit-details-marker {
-      display: none;
-    }
+    overflow-y: auto;
   }
 
   @container group-card (min-width: 42rem) {

--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -1,135 +1,233 @@
 <script>
+  /*
+   * SwitchSidesButton uses `onclick`; GroupMemberCard uses `onBack` to return to the front.
+   */
+  import { browser } from "$app/environment";
   import DetailsUpIcon from "$lib/assets/svg/DetailsUpIcon.svelte";
   import GroupCardHeader from "$lib/components/groups/GroupCardHeader.svelte";
   import GroupInviteForm from "$lib/components/groups/GroupInviteForm.svelte";
+  import GroupMemberCard from "$lib/components/groups/GroupMemberCard.svelte";
+  import SwitchSidesButton from "$lib/components/groups/SwitchSidesButton.svelte";
   import UserSectionDropdown from "$lib/components/groups/UserSectionDropdown.svelte";
-  import avatar from "$lib/assets/img/profile-avatar.webp";
+  import previewAvatarFallback from "$lib/assets/img/profile-avatar.webp";
 
-  // Group data is passed from the groups page
-  export let group;
+  let { group } = $props();
 
-  // Fallback values keep the component safe while API data is still incomplete
-  $: groupName = group?.name ?? "Unnamed group";
-  $: groupStatus = group?.status ?? "Unknown";
-  $: conditionLabel = group?.conditionlabel ?? "General";
-  $: memberCount = group?.memberCount ?? 0;
+  let flipped = $state(false);
 
+  const groupId = $derived(group?.id ?? "");
+  const frontFaceId = $derived(`group-${groupId}`);
+  const membersFaceId = $derived(`group-${groupId}-members`);
 
- // Max number of member avatars to show in the preview
-  const MAX_PREVIEW_MEMBERS = 2;
-
-  // Reactive plural check to avoid magic numbers in the template
-  $: isPlural = memberCount !== 1;
-
-  // Create temporary preview items with stable ids for rendering
-  $: previewMembers =
-    memberCount > 0
-      ? Array.from({ length: Math.min(memberCount, MAX_PREVIEW_MEMBERS) }, (_, index) => ({
-          id: index + 1,
-          name: null // Name is not available yet until member API data is connected
-        }))
-      : [];
+  const groupName = $derived(group?.name ?? "Unnamed group");
+  const groupStatus = $derived(group?.status ?? "Unknown");
+  const conditionLabel = $derived(group?.conditionlabel ?? "General");
+  const membersList = $derived(
+    Array.isArray(group?.members) ? group.members : []
+  );
+  const memberCount = $derived(membersList.length);
+  const isPlural = $derived(memberCount !== 1);
+  const previewMembers = $derived(membersList.slice(0, 3));
 </script>
 
-<article>
-  <GroupCardHeader
-  name={groupName}
-  status={groupStatus}
-  conditionLabel={conditionLabel}
-/>
+<article class="group-card-root">
+  <div class="scene">
+    <div class="flipper" class:flipped={flipped}>
+      <div
+        id={frontFaceId}
+        class="face face--front"
+        inert={browser && flipped}
+        aria-hidden={browser && flipped}
+      >
+        <header class="group-card-header">
+          <SwitchSidesButton
+            onclick={() => {
+              flipped = true;
+            }}
+          />
+          <GroupCardHeader
+            name={groupName}
+            status={groupStatus}
+            conditionLabel={conditionLabel}
+          />
+        </header>
 
-  <section class="members-section">
-    <h2 class="title">Members</h2>
+        <section class="members-section">
+          <h2 class="title">Members</h2>
 
-    <!-- Temporary member preview until real member data is available -->
-  {#if previewMembers.length > 0}
-      <ul aria-label="Current members preview">
-        {#each previewMembers as member (member.id)}
-          <li>
-    <img src={avatar} alt={`Group member ${member.id}`} />
-  </li>
-{/each}
-  </ul>
-{:else}
-  <p class="members-empty">No members available yet.</p>
-{/if}
+          {#if previewMembers.length > 0}
+            <ul aria-label="Current members preview">
+              {#each previewMembers as member (member.id)}
+                <li>
+                  <img
+                    class="members-preview-av"
+                    src={member.avatarUrl ?? previewAvatarFallback}
+                    alt=""
+                    width="48"
+                    height="48"
+                    decoding="async"
+                  />
+                </li>
+              {/each}
+            </ul>
+          {:else}
+            <p class="members-empty">No members available yet.</p>
+          {/if}
 
-    <GroupInviteForm />
-  </section>
+          <GroupInviteForm />
+        </section>
 
-  <details>
-    <summary>
-       <!-- Member count is currently based on fallback data -->
-       <span>{memberCount} member{isPlural ? 's' : ''}</span>
-      <span class="chevron">
-        <DetailsUpIcon />
-      </span>
-    </summary>
-    <UserSectionDropdown />
-  </details>
+        <details>
+          <summary>
+            <span>{memberCount} member{isPlural ? "s" : ""}</span>
+            <span class="chevron">
+              <DetailsUpIcon />
+            </span>
+          </summary>
+          <UserSectionDropdown />
+        </details>
+      </div>
+
+      <div
+        id={membersFaceId}
+        class="face face--back"
+        inert={browser && !flipped}
+        aria-hidden={browser && !flipped}
+      >
+        <GroupMemberCard
+          {groupId}
+          onBack={() => {
+            flipped = false;
+          }}
+        />
+      </div>
+    </div>
+  </div>
 </article>
 
 <style>
-  article {
+  .group-card-root {
     width: min(100%, 24rem);
+    container-type: inline-size;
+    container-name: group-card;
+    perspective: 1000px;
+  }
+
+  .scene {
+    position: relative;
+    min-height: 28rem;
+  }
+
+  .flipper {
+    position: relative;
+    min-height: 28rem;
+    transform-style: preserve-3d;
+    transition: transform 0.65s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .flipper.flipped {
+    transform: rotateY(180deg);
+  }
+
+  .face {
+    position: absolute;
+    inset: 0;
     border-radius: var(--radius-xl);
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
     overflow: hidden;
     background: var(--background-color-primary);
     box-shadow: var(--shadow-lg);
-    transition: box-shadow var(--transition-slow);
-    container-type: inline-size;
-    container-name: group-card;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .face--back {
+    transform: rotateY(180deg);
+  }
+
+  .group-card-header {
+    position: relative;
+
+    & :global(.switch-sides-btn) {
+      position: absolute;
+      top: var(--spacing-xl);
+      right: 0;
+      z-index: 10;
+    }
   }
 
   .members-section {
     padding: var(--spacing-lg);
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
 
     ul {
+      display: flex;
+      gap: var(--spacing-xs);
       margin: 0 0 var(--spacing-lg);
       padding: 0;
       list-style: none;
+    }
+  }
+
+  .members-preview-av {
+    width: 3rem;
+    height: 3rem;
+    border-radius: var(--radius-full);
+    border: 2px solid var(--background-color-primary);
+    object-fit: cover;
+    object-position: center;
+    background: var(--grey-100);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .title {
+    margin: 0 0 var(--spacing-sm);
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--grey-700);
+  }
+
+  .members-empty {
+    margin: 0 0 var(--spacing-lg);
+    font-size: 0.875rem;
+    color: var(--grey-500);
+  }
+
+  details {
+    flex-shrink: 0;
+
+    summary {
       display: flex;
-      gap: var(--spacing-xs);
+      width: 100%;
+      justify-content: space-between;
+      align-items: center;
+      padding: var(--spacing-md) var(--spacing-lg);
+      border-top: 1px solid var(--grey-100);
+      background: var(--grey-50);
+      color: var(--grey-600);
+      list-style: none;
+      cursor: pointer;
 
-      li {
-        margin-left: 0;
+      &::-webkit-details-marker {
+        display: none;
       }
 
-      img {
-        width: 3rem;
-        height: 3rem;
-        border-radius: var(--radius-full);
-        border: 2px solid var(--background-color-primary);
-        object-fit: cover;
-        box-shadow: var(--shadow-sm);
+      .chevron {
+        display: inline-flex;
+        transition: transform var(--transition-slow);
+
+        @media (prefers-reduced-motion: reduce) {
+          transition: none;
+        }
       }
     }
-  }
 
-  summary {
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: var(--spacing-md) var(--spacing-lg);
-    border-top: 1px solid var(--grey-100);
-    background: var(--grey-50);
-    color: var(--grey-600);
-    list-style: none;
-    cursor: pointer;
-
-    &::-webkit-details-marker {
-      display: none;
+    &[open] summary .chevron {
+      transform: rotate(180deg);
     }
-  }
-
-  .chevron {
-    display: inline-flex;
-    transition: transform var(--transition-slow);
-  }
-
-  details[open] .chevron {
-    transform: rotate(180deg);
   }
 
   @container group-card (min-width: 42rem) {
@@ -139,8 +237,11 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    article,
-    .chevron {
+    .flipper {
+      transition: none;
+    }
+
+    details summary .chevron {
       transition: none;
     }
   }

--- a/src/lib/components/groups/GroupMemberCard.svelte
+++ b/src/lib/components/groups/GroupMemberCard.svelte
@@ -7,18 +7,18 @@
   // Builds correct app URLs when the site uses a base path (SvelteKit `resolve`).
   import { resolve } from '$app/paths'
 
-  // TODO(groups): Swap the constants below for real `groupName` and `members` from props when the API is ready.
-  const PLACEHOLDER_AVATAR = 'https://placehold.co/96x96/e2e8f0/64748b?text=%20'
-
-  const groupName = 'Prevention'
-  const members = [
-    { id: 701, name: 'Yamen Al Sharabi', role: 'Super Admin', avatarUrl: PLACEHOLDER_AVATAR },
-    { id: 702, name: 'Alex ', role: 'Member', avatarUrl: PLACEHOLDER_AVATAR },
-    { id: 703, name: 'Sam ', role: 'Member', avatarUrl: PLACEHOLDER_AVATAR }
-  ]
+  /**
+   * @typedef {{ id: number | string; name: string; role?: string; avatarUrl?: string }} MemberRow
+   */
 
   // With `onBack` from GroupCard, “Back” is a button (no URL change). Without it, `groupId` builds an optional hash link.
-  let { groupId = '', onBack } = $props()
+  let {
+    groupId = '',
+    onBack,
+    groupName = '',
+    /** @type {MemberRow[]} */
+    members = []
+  } = $props()
 
   const backHref = $derived(
     onBack
@@ -32,7 +32,7 @@
 <!-- Root: full-height column; header fixed style, list grows and scrolls -->
 <div class="card">
   <header class="header">
-    <span class="group-name">{groupName}</span>
+    <span class="group-name">{groupName || 'Unnamed group'}</span>
     {#if onBack}
       <button type="button" class="back" onclick={onBack}>Back</button>
     {:else if backHref}

--- a/src/lib/components/groups/GroupMemberCard.svelte
+++ b/src/lib/components/groups/GroupMemberCard.svelte
@@ -17,12 +17,15 @@
     { id: 703, name: 'Sam ', role: 'Member', avatarUrl: PLACEHOLDER_AVATAR }
   ]
 
-  // Only input from the parent: which card we belong to, so “Back” can open the front face (`#group-7`, etc.).
-  let { groupId = '' } = $props()
+  // With `onBack` from GroupCard, “Back” is a button (no URL change). Without it, `groupId` builds an optional hash link.
+  let { groupId = '', onBack } = $props()
 
-  // Recomputes whenever `groupId` changes. Empty string → no link (button only).
   const backHref = $derived(
-    groupId !== '' && groupId != null ? `${resolve('/groups')}#group-${groupId}` : ''
+    onBack
+      ? ''
+      : groupId !== '' && groupId != null
+        ? `${resolve('/groups')}#group-${groupId}`
+        : ''
   )
 </script>
 
@@ -30,12 +33,12 @@
 <div class="card">
   <header class="header">
     <span class="group-name">{groupName}</span>
-    {#if backHref}
-      <!-- Real URL: eslint rule skipped because href is already built with `resolve()` above -->
+    {#if onBack}
+      <button type="button" class="back" onclick={onBack}>Back</button>
+    {:else if backHref}
       <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
       <a class="back" href={backHref}>Back</a>
     {:else}
-      <!-- No `groupId`: still show Back visually, but it cannot navigate -->
       <button type="button" class="back">Back</button>
     {/if}
   </header>
@@ -107,8 +110,8 @@
       cursor: pointer;
       text-decoration: none;
 
-      /* Visible keyboard focus only on the real link (not the button fallback) */
-      &:is(a):focus-visible {
+      &:is(a):focus-visible,
+      &:focus-visible {
         outline: 2px solid var(--background-color-primary);
         outline-offset: 2px;
       }

--- a/src/lib/components/groups/GroupMemberCard.svelte
+++ b/src/lib/components/groups/GroupMemberCard.svelte
@@ -1,0 +1,181 @@
+<script>
+  /*
+   * GroupMemberCard — back face of the flipped group card.
+   * Shows a title bar, a “Back” control, and a scrollable list of members.
+   */
+
+  // Builds correct app URLs when the site uses a base path (SvelteKit `resolve`).
+  import { resolve } from '$app/paths'
+
+  // TODO(groups): Swap the constants below for real `groupName` and `members` from props when the API is ready.
+  const PLACEHOLDER_AVATAR = 'https://placehold.co/96x96/e2e8f0/64748b?text=%20'
+
+  const groupName = 'Prevention'
+  const members = [
+    { id: 701, name: 'Yamen Al Sharabi', role: 'Super Admin', avatarUrl: PLACEHOLDER_AVATAR },
+    { id: 702, name: 'Alex ', role: 'Member', avatarUrl: PLACEHOLDER_AVATAR },
+    { id: 703, name: 'Sam ', role: 'Member', avatarUrl: PLACEHOLDER_AVATAR }
+  ]
+
+  // Only input from the parent: which card we belong to, so “Back” can open the front face (`#group-7`, etc.).
+  let { groupId = '' } = $props()
+
+  // Recomputes whenever `groupId` changes. Empty string → no link (button only).
+  const backHref = $derived(
+    groupId !== '' && groupId != null ? `${resolve('/groups')}#group-${groupId}` : ''
+  )
+</script>
+
+<!-- Root: full-height column; header fixed style, list grows and scrolls -->
+<div class="card">
+  <header class="header">
+    <span class="group-name">{groupName}</span>
+    {#if backHref}
+      <!-- Real URL: eslint rule skipped because href is already built with `resolve()` above -->
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+      <a class="back" href={backHref}>Back</a>
+    {:else}
+      <!-- No `groupId`: still show Back visually, but it cannot navigate -->
+      <button type="button" class="back">Back</button>
+    {/if}
+  </header>
+
+  <!-- `(member.id)` = Svelte key so rows reconcile correctly when the list changes later -->
+  <ul class="members" aria-label="Group members">
+    {#each members as member (member.id)}
+      <li class="row">
+        <img
+          class="avatar"
+          src={member.avatarUrl}
+          alt={`Avatar of ${member.name}`}
+          width="32"
+          height="32"
+          decoding="async"
+        />
+        <div class="meta">
+          <span class="name">{member.name}</span>
+          <span class="role">{member.role}</span>
+        </div>
+      </li>
+    {:else}
+      <li class="row empty">No members in this group yet.</li>
+    {/each}
+  </ul>
+</div>
+
+<style>
+  /* Card fills the flip face; min-height 0 lets the inner list scroll inside flex layouts */
+  .card {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    background: var(--background-color-primary);
+
+    /* Top bar: group title left, Back right */
+    & .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--spacing-sm);
+      padding: var(--spacing-md) var(--spacing-lg);
+      background: hsl(292.04deg 45.75% 51.57%);
+      color: var(--font-color-card);
+    }
+
+    /* Group title in the purple bar */
+    & .group-name {
+      font-size: 1rem;
+      font-weight: 700;
+      line-height: 1.25;
+    }
+
+    /* Same look for `<a>` and `<button>`; keyboard users get a clear focus ring on the link */
+    & .back {
+      flex-shrink: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: none;
+      border-radius: var(--radius-md);
+      padding: 0.5rem 0.75rem;
+      background: var(--background-color-primary);
+      color: hsl(263, 70%, 50%);
+      font: inherit;
+      font-size: 0.75rem;
+      font-weight: 700;
+      cursor: pointer;
+      text-decoration: none;
+
+      /* Visible keyboard focus only on the real link (not the button fallback) */
+      &:is(a):focus-visible {
+        outline: 2px solid var(--background-color-primary);
+        outline-offset: 2px;
+      }
+    }
+
+    /* Member list takes remaining height; scrolls if there are many rows */
+    & .members {
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    /* One member row: avatar + text; empty state is a single full-width message */
+    & .row {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-sm);
+      padding: var(--spacing-sm) var(--spacing-lg);
+      border-bottom: 1px solid var(--grey-100);
+
+      /* Avoid a double line under the last item */
+      &:last-child {
+        border-bottom: none;
+      }
+
+      /* Shown when the members array is empty (not used with current static demo) */
+      &.empty {
+        display: block;
+        padding: var(--spacing-lg);
+        color: var(--grey-500);
+        font-size: 1rem;
+      }
+    }
+
+    /* Square image cropped to a circle; grey background shows while the image loads */
+    & .avatar {
+      flex-shrink: 0;
+      width: 2rem;
+      height: 2rem;
+      border-radius: var(--radius-full);
+      object-fit: cover;
+      object-position: center;
+      background: var(--grey-100);
+    }
+
+    /* Stacks name + role; min-width 0 stops long names from breaking the flex row */
+    & .meta {
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    /* Member display name */
+    & .name {
+      font-size: 1rem;
+      font-weight: 500;
+      color: var(--grey-700);
+    }
+
+    /* Role / status line, slightly smaller and muted */
+    & .role {
+      font-size: 0.75rem;
+      color: var(--grey-400);
+    }
+  }
+</style>

--- a/src/lib/components/groups/SwitchSidesButton.svelte
+++ b/src/lib/components/groups/SwitchSidesButton.svelte
@@ -1,19 +1,25 @@
 <script>
   import SwitchSidesIcon from "$lib/assets/svg/SwitchSidesIcon.svelte";
 
-  /** Same-document hash (e.g. `#group-12-members`) so the card flips without JS via `:target` CSS. */
-  let { label = "Members", disabled = false, href } = $props();
+  /** Use `onclick` to flip without changing the URL, or `href` for a normal link (optional). */
+  let { label = "Members", disabled = false, href, onclick } = $props();
 </script>
 
-{#if disabled || !href}
+{#if disabled || (!href && !onclick)}
   <span class="switch-sides-btn" aria-disabled="true">
     <span class="switch-sides-btn__icon" aria-hidden="true">
       <SwitchSidesIcon width={19} height={19} />
     </span>
     <span class="switch-sides-btn__text">{label}</span>
   </span>
+{:else if onclick}
+  <button type="button" class="switch-sides-btn" {onclick}>
+    <span class="switch-sides-btn__icon" aria-hidden="true">
+      <SwitchSidesIcon width={19} height={19} />
+    </span>
+    <span class="switch-sides-btn__text">{label}</span>
+  </button>
 {:else}
-  <!-- Caller builds `href` with `resolve()` (fragment navigation for progressive enhancement). -->
   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
   <a class="switch-sides-btn" {href}>
     <span class="switch-sides-btn__icon" aria-hidden="true">
@@ -29,6 +35,7 @@
     align-items: center;
     gap: var(--spacing-xs);
     margin: 0;
+    appearance: none;
     padding: var(--spacing-sm) var(--spacing-md);
     border: none;
     border-radius: 10px 0 0 10px;
@@ -55,7 +62,8 @@
       outline-offset: 2px;
     }
 
-    &[aria-disabled="true"] {
+    &[aria-disabled="true"],
+    &:disabled {
       opacity: 0.5;
       cursor: not-allowed;
       box-shadow: none;

--- a/src/lib/components/groups/SwitchSidesButton.svelte
+++ b/src/lib/components/groups/SwitchSidesButton.svelte
@@ -1,0 +1,78 @@
+<script>
+  import SwitchSidesIcon from "$lib/assets/svg/SwitchSidesIcon.svelte";
+
+  /** Same-document hash (e.g. `#group-12-members`) so the card flips without JS via `:target` CSS. */
+  let { label = "Members", disabled = false, href } = $props();
+</script>
+
+{#if disabled || !href}
+  <span class="switch-sides-btn" aria-disabled="true">
+    <span class="switch-sides-btn__icon" aria-hidden="true">
+      <SwitchSidesIcon width={19} height={19} />
+    </span>
+    <span class="switch-sides-btn__text">{label}</span>
+  </span>
+{:else}
+  <!-- Caller builds `href` with `resolve()` (fragment navigation for progressive enhancement). -->
+  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+  <a class="switch-sides-btn" {href}>
+    <span class="switch-sides-btn__icon" aria-hidden="true">
+      <SwitchSidesIcon width={19} height={19} />
+    </span>
+    <span class="switch-sides-btn__text">{label}</span>
+  </a>
+{/if}
+
+<style>
+  .switch-sides-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    margin: 0;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border: none;
+    border-radius: 10px 0 0 10px;
+    background: var(--background-color-primary);
+    color: var(--grey-500);
+    font: 500 clamp(12px, 2vw, 13px) / 1.2 var(--main-font);
+    white-space: nowrap;
+    cursor: pointer;
+    box-shadow: var(--shadow-sm);
+    text-decoration: none;
+    transition:
+      box-shadow var(--transition-fast),
+      color var(--transition-fast),
+      transform var(--transition-fast);
+
+    &:hover:not([aria-disabled="true"]) {
+      color: var(--grey-600);
+      box-shadow: var(--shadow-md);
+      transform: translateY(-0.5px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--blue-500);
+      outline-offset: 2px;
+    }
+
+    &[aria-disabled="true"] {
+      opacity: 0.5;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
+    .switch-sides-btn__icon {
+      display: flex;
+      flex-shrink: 0;
+      color: currentColor;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+
+      &:hover:not([aria-disabled="true"]) {
+        transform: none;
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
## What does this change?

Resolves issue #336 #337

Adds a card flip interaction to the group card. Clicking the Members 
button flips the card 180° to reveal a back face listing the group's 
members. Clicking Back flips it back to the front.

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [x] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images
<img width="1582" height="1035" alt="Screenshot 2026-04-20 at 16 37 54" src="https://github.com/user-attachments/assets/e9885e87-72e2-4304-a324-b4eda9b635f6" />



<img width="1582" height="1035" alt="Screenshot 2026-04-20 at 16 37 56" src="https://github.com/user-attachments/assets/eddb96b2-c07e-468c-a25c-f2c3d8ba120a" />

## How to review


1. Pull the branch and open the groups page
2. Click the **Members** button on any group card — card should flip 
   smoothly to show the members list
3. Click **Back** — card should flip back to the front
4. Tab through the card in both states — only the visible face should 
   be reachable by keyboard
