### PR TITLE
346 feature add member fetching to the group page

### DIFF
--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -3,7 +3,7 @@
   import GroupCardHeader from "$lib/components/groups/GroupCardHeader.svelte";
   import GroupInviteForm from "$lib/components/groups/GroupInviteForm.svelte";
   import UserSectionDropdown from "$lib/components/groups/UserSectionDropdown.svelte";
-  import avatar from "$lib/assets/img/profile-avatar.webp";
+  import fallbackAvatar from "$lib/assets/img/profile-avatar.webp";
 
   // Group data is passed from the groups page
   export let group;
@@ -13,14 +13,9 @@
   $: groupStatus = group?.status ?? "Unknown";
   $: conditionLabel = group?.conditionlabel ?? "General";
 
-  // Members array from group data, fallback to empty array
-  // TODO: Replace with real member data from Directus when API is connected
-//   $: members = group?.members?.length > 0 ? group.members : [
-//   { id: 1, name: "Yamen Al", email: "yamen@example.com" },
-//   { id: 2, name: "John Doe", email: "john@example.com" }
-// ];
-  $: members = group?.members ?? [];
-  $: memberCount = members.length > 0 ? members.length : (group?.memberCount ?? 0);
+  // Members are fetched on the server and attached to each group
+  $: members = Array.isArray(group?.members) ? group.members : [];
+  $: memberCount = group?.memberCount ?? members.length;
 
 
  // Max number of member avatars to show in the preview
@@ -29,14 +24,8 @@
   // Reactive plural check to avoid magic numbers in the template
   $: isPlural = memberCount !== 1;
 
-  // Create temporary preview items with stable ids for rendering
-  $: previewMembers =
-    memberCount > 0
-      ? Array.from({ length: Math.min(memberCount, MAX_PREVIEW_MEMBERS) }, (_, index) => ({
-          id: index + 1,
-          name: null // Name is not available yet until member API data is connected
-        }))
-      : [];
+  // Show only first members in card preview row
+  $: previewMembers = members.slice(0, MAX_PREVIEW_MEMBERS);
 </script>
 
 <article>
@@ -55,8 +44,7 @@
         <ul aria-label="Current members preview">
           {#each previewMembers as member (member.id)}
             <li>
-              <!-- Avatar image is managed via Directus, no changes needed here -->
-              <img src={avatar} alt={member.name ?? `Group member ${member.id}`} />
+              <img src={member.avatarUrl ?? fallbackAvatar} alt={member.name ?? `Group member ${member.id}`} />
             </li>
           {/each}
         </ul>

--- a/src/lib/components/groups/UserSectionDropdown.svelte
+++ b/src/lib/components/groups/UserSectionDropdown.svelte
@@ -14,8 +14,10 @@
        <li>
         <img src={member.avatarUrl ?? fallbackAvatar} alt={member.name ?? 'Team member'} />
 
-        <!-- Member name -->
-        <span class="member-name">{member.name ?? 'Unknown'}</span>
+        <div class="member-meta">
+          <span class="member-name">{member.name ?? 'Unknown'}</span>
+          <span class="member-role">{member.role ?? 'No role assigned'}</span>
+        </div>
 
         <!-- Remove button: grey circle with minus icon only — no text, no red -->
         <form method="POST" action="?/remove">
@@ -77,6 +79,18 @@ li {
     color: var(--grey-700);
     font-weight: 500;    
     font-size: var(--font-size-sm);
+    text-align: left;
+  }
+
+  .member-meta {
+    display: grid;
+    gap: 0.125rem;
+  }
+
+  .member-role {
+    color: var(--grey-500);
+    font-size: var(--font-size-xs, 0.75rem);
+    line-height: 1.2;
     text-align: left;
   }
 

--- a/src/lib/components/groups/UserSectionDropdown.svelte
+++ b/src/lib/components/groups/UserSectionDropdown.svelte
@@ -1,5 +1,5 @@
 <script>
-  import avatar from '$lib/assets/img/profile-avatar.webp';
+  import fallbackAvatar from '$lib/assets/img/profile-avatar.webp';
 
   // Members are passed from GroupCard.svelte
   // Each member can have: id, name, email, isEmpty (open slot)
@@ -12,8 +12,7 @@
    <ul>
     {#each members as member (member.id)}
        <li>
-        <!-- Member avatar image (managed via Directus, no changes needed here) -->
-        <img src={avatar} alt={member.name ?? 'Team member'} />
+        <img src={member.avatarUrl ?? fallbackAvatar} alt={member.name ?? 'Team member'} />
 
         <!-- Member name -->
         <span class="member-name">{member.name ?? 'Unknown'}</span>

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -3,6 +3,10 @@
 // Uses the footguard_workgroups collection.
 
 import { DIRECTUS_URL, DIRECTUS_TOKEN } from '$env/static/private'
+
+function buildDirectusAssetUrl(fileId) {
+  return fileId ? `${DIRECTUS_URL}/assets/${fileId}` : null
+}
 /**
  * Fetches all workgroups from Directus.
  * Member count is 0 for now since footguard_group_members has no data yet.
@@ -11,35 +15,72 @@ import { DIRECTUS_URL, DIRECTUS_TOKEN } from '$env/static/private'
  * @throws {Error} If the API call fails
  */
 export async function fetchGroups() {
-  const url = `${DIRECTUS_URL}/items/footguard_workgroups?fields=id,group_name,status,condition_label,created_by_user_id`
+  const groupsUrl = `${DIRECTUS_URL}/items/footguard_workgroups?fields=id,group_name,status,condition_label,created_by_user_id`
+  const membersUrl = `${DIRECTUS_URL}/items/footguard_group_members?fields=id,workgroup_id,membership_status,user_id.id,user_id.name,user_id.email,user_id.photo&filter[membership_status][_eq]=active&limit=-1`
 
-  let response
+  let groupsResponse
+  let membersResponse
 
   try {
-    response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${DIRECTUS_TOKEN}`,
-        'Content-Type': 'application/json'
-      }
-    })
+    const headers = {
+      Authorization: `Bearer ${DIRECTUS_TOKEN}`,
+      'Content-Type': 'application/json'
+    }
+
+    ;[groupsResponse, membersResponse] = await Promise.all([
+      fetch(groupsUrl, { headers }),
+      fetch(membersUrl, { headers })
+    ])
   } catch (networkError) {
     // Fetch itself failed (e.g. no internet, Directus unreachable)
     throw new Error(`Network error while connecting to Directus: ${networkError.message}`)
   }
 
   // Handle non-2xx HTTP responses from Directus
-  if (!response.ok) {
-    throw new Error(`Directus API error: ${response.status} ${response.statusText}`)
+  if (!groupsResponse.ok) {
+    throw new Error(`Directus API error: ${groupsResponse.status} ${groupsResponse.statusText}`)
   }
 
-  const json = await response.json()
+  if (!membersResponse.ok) {
+    throw new Error(`Directus API error: ${membersResponse.status} ${membersResponse.statusText}`)
+  }
+
+  const groupsJson = await groupsResponse.json()
+  const membersJson = await membersResponse.json()
+
+  const groupMembersByGroupId = new Map()
+
+  for (const member of membersJson.data ?? []) {
+    const groupId = member?.workgroup_id
+    const user = member?.user_id
+
+    if (!groupId || !user || typeof user !== 'object') {
+      continue
+    }
+
+    const mappedMember = {
+      id: user.id ?? member.id,
+      name: user.name ?? 'Unknown',
+      email: user.email ?? null,
+      avatarUrl: buildDirectusAssetUrl(user.photo)
+    }
+
+    const currentMembers = groupMembersByGroupId.get(groupId) ?? []
+    currentMembers.push(mappedMember)
+    groupMembersByGroupId.set(groupId, currentMembers)
+  }
 
   // Map the raw Directus response to a clean UI-friendly format
-  return json.data.map((group) => ({
-    id: group.id,
-    name: group.group_name,
-    status: group.status,
-    conditionlabel: group.condition_label ?? 'General', // fallback if null
-    memberCount: 0 // footguard_group_members is empty for now
-  }))
+  return (groupsJson.data ?? []).map((group) => {
+    const members = groupMembersByGroupId.get(group.id) ?? []
+
+    return {
+      id: group.id,
+      name: group.group_name,
+      status: group.status,
+      conditionlabel: group.condition_label ?? 'General', // fallback if null
+      members,
+      memberCount: members.length
+    }
+  })
 }

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -16,7 +16,7 @@ function buildDirectusAssetUrl(fileId) {
  */
 export async function fetchGroups() {
   const groupsUrl = `${DIRECTUS_URL}/items/footguard_workgroups?fields=id,group_name,status,condition_label,created_by_user_id`
-  const membersUrl = `${DIRECTUS_URL}/items/footguard_group_members?fields=id,workgroup_id,membership_status,user_id.id,user_id.name,user_id.email,user_id.photo&filter[membership_status][_eq]=active&limit=-1`
+  const membersUrl = `${DIRECTUS_URL}/items/footguard_group_members?fields=id,workgroup_id,member_role,membership_status,user_id.id,user_id.name,user_id.email,user_id.photo&filter[membership_status][_eq]=active&limit=-1`
 
   let groupsResponse
   let membersResponse
@@ -61,6 +61,7 @@ export async function fetchGroups() {
     const mappedMember = {
       id: user.id ?? member.id,
       name: user.name ?? 'Unknown',
+      role: member?.member_role ?? null,
       email: user.email ?? null,
       avatarUrl: buildDirectusAssetUrl(user.photo)
     }

--- a/src/routes/groups/+page.server.js
+++ b/src/routes/groups/+page.server.js
@@ -2,11 +2,7 @@
 // Fetches workgroup data from Directus before the page renders.
 // The API token stays secure because this code only runs on the server.
 
-import {
-  fetchGroups,
-  findUserByEmail,
-  addUserToGroup
-} from '$lib/server/groups.js'
+import { fetchGroups, findUserByEmail, addUserToGroup } from '$lib/server/groups.js'
 import { error, fail } from '@sveltejs/kit'
 
 /** @type {import('./$types').PageServerLoad} */

--- a/src/routes/groups/+page.server.js
+++ b/src/routes/groups/+page.server.js
@@ -5,8 +5,7 @@
 import {
   fetchGroups,
   findUserByEmail,
-  addUserToGroup,
-  getGroupMembers
+  addUserToGroup
 } from '$lib/server/groups.js'
 import { error, fail } from '@sveltejs/kit'
 
@@ -15,23 +14,9 @@ export async function load() {
   try {
     const groups = await fetchGroups()
 
-    // Fetch pending invites for each group in parallel
-    // can show member names and avatars on page load
-    const groupsWithMembers = await Promise.all(
-      groups.map(async (group) => {
-        try {
-          const members = await getGroupMembers(group.id)
-          return { ...group, members, memberCount: members.length }
-        } catch {
-          // If fetching invites fails for one group, don't crash the whole page
-          // just return the group with an empty pending list
-          return { ...group, members: [], memberCount: 0 }
-        }
-      })
-    )
     // Pass groups (with their members) to +page.svelte via the data prop
     return {
-      groups: groupsWithMembers,
+      groups,
       loadError: null
     }
   } catch {


### PR DESCRIPTION
## What does this change?

Resolves issue #346

This PR connects real group member data from Directus and renders it in the groups UI.

fetches members from footguard_group_members on the server
maps members to groups by [workgroup_id](vscode-file://vscode-app/c:/Users/bigil/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
includes member name, email, and avatar URL
shows real avatars in GroupCard preview (max 2)
shows real avatars + names in dropdown

## How Has This Been Tested?

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<img width="1638" height="901" alt="image" src="https://github.com/user-attachments/assets/95f92476-8839-4327-b7d5-19dce4e95b4a" />

## How to review
1. Open the Groups page on this branch.
2. Confirm each group card shows real member avatars.
3. Open the dropdown and verify names + avatars are correct.
