### PR TITLE
337 bug member card

### DIFF
--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -120,7 +120,9 @@
               <DetailsUpIcon />
             </span>
           </summary>
-          <UserSectionDropdown {members} />
+          <div class="members-dropdown-panel">
+            <UserSectionDropdown {members} />
+          </div>
         </details>
       </div>
 
@@ -141,10 +143,18 @@
 
 <style>
   .group-card-root {
-    width: min(100%, 24rem);
+    position: relative;
+    width: 100%;
+    max-width: 24rem;
+    justify-self: start;
     container-type: inline-size;
     container-name: group-card;
     perspective: 1000px;
+  }
+
+  .group-card-root:has(.face--front details[open]) {
+    z-index: 30;
+    margin-bottom: 10rem;
   }
 
   .scene {
@@ -180,9 +190,16 @@
     transform: rotateY(180deg);
   }
 
+  .face--front {
+    overflow: visible;
+    border-radius: var(--radius-xl);
+  }
+
   .group-card-header {
     position: relative;
     flex-shrink: 0;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+    overflow: hidden;
 
     & :global(.switch-sides-btn) {
       position: absolute;
@@ -255,7 +272,36 @@
   }
 
   details {
+    position: relative;
     flex-shrink: 0;
+    overflow: visible;
+
+    & > .members-dropdown-panel {
+      display: none;
+    }
+
+    &[open] > .members-dropdown-panel {
+      display: block;
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      z-index: 40;
+      max-height: 10rem;
+      overflow-y: auto;
+      background: var(--background-color-primary);
+      border-top: 1px solid var(--grey-100);
+      border-radius: 0 0 var(--radius-xl) var(--radius-xl);
+      box-shadow: none;
+    }
+
+    &[open] summary .chevron {
+      transform: rotate(180deg);
+    }
+
+    &[open] summary {
+      border-radius: 0;
+    }
 
     summary {
       display: flex;
@@ -268,6 +314,7 @@
       color: var(--grey-600);
       list-style: none;
       cursor: pointer;
+      border-radius: 0 0 var(--radius-xl) var(--radius-xl);
 
       &::-webkit-details-marker {
         display: none;

--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -129,6 +129,8 @@
         <GroupMemberCard
           {groupId}
           {groupName}
+          {memberCount}
+          memberLimit={group?.maxMembers ?? null}
           members={membersForBackFace}
           onBack={flipToFront}
         />

--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -197,6 +197,9 @@
     margin-bottom: var(--spacing-lg);
 
     ul {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-xs);
       margin: 0;
       padding: 0;
       list-style: none;

--- a/src/lib/components/groups/GroupInviteForm.svelte
+++ b/src/lib/components/groups/GroupInviteForm.svelte
@@ -9,19 +9,11 @@
    /** @type {string} - The ID of the group this form belongs to */
   export let groupId
 
-  /** @type {Array} - Current active members of this group */
-  export let members = []
-
-
   // Local state for the email input
   let email = ''
   let isSubmitting = false
   let localError = ''
   let localSuccess = false
-
-  // Local copy of pending invites so we can update the UI instantly
-  // without waiting for a full page reload
-  let localMembers = [...members]
 
    /**
    * Client-side email validation before the form is submitted.
@@ -61,16 +53,6 @@
       isSubmitting = false
 
       if (result.type === 'success' && result.data?.groupId === groupId) {
-        // Add the newly invited email to the local pending list immediately
-        // so the user sees the update without waiting for a page reload
-         localMembers = [
-          ...localMembers,
-          {
-            id: Date.now(), // temporary ID until the page reloads
-            name: result.data.userName,
-            email: result.data.email
-          }
-        ]
         localSuccess = true
         email = '' // Clear the input field after a successful invite
 
@@ -121,19 +103,6 @@
 <!-- Success feedback: shown briefly after a member is successfully added -->
 {#if localSuccess}
   <p class="feedback success" role="status">✓ Member added successfully!</p>
-{/if}
-
-<!-- Member list: shows all members that were added in this session -->
-{#if localMembers.length > 0}
-  <ul class="members-list">
-    {#each localMembers as member (member.id)}
-      <li class="member-item">
-        <!-- Show the member's full name, fall back to email if name is missing -->
-        <span class="member-name">{member.name || member.email}</span>
-        <span class="member-email">{member.email}</span>
-      </li>
-    {/each}
-  </ul>
 {/if}
 
 <style>
@@ -188,35 +157,6 @@
     background: var(--green-50, #f0fdf4);
   }
 }
-
-  /* Member list shown below the form after adding */
-  .members-list {
-    list-style: none;
-    padding: 0;
-    margin: var(--spacing-sm) 0 0;
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
-  }
-
-   .member-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    font-size: 0.8rem;
-    padding: var(--spacing-xs) var(--spacing-sm);
-    background: var(--grey-50, #f9fafb);
-    border-radius: var(--radius-sm);
-  }
-
-  .member-name {
-    color: var(--grey-800);
-    font-weight: 500;
-  }
-
-  .member-email {
-    color: var(--grey-500);
-  }
 
   @container invite-form (min-width: 42rem) {
     form {

--- a/src/lib/components/groups/GroupMemberCard.svelte
+++ b/src/lib/components/groups/GroupMemberCard.svelte
@@ -15,6 +15,7 @@
   let {
     groupId = '',
     onBack,
+    groupName = '',
     memberCount = 0,
     memberLimit = null,
     /** @type {MemberRow[]} */
@@ -35,7 +36,7 @@
   )
 </script>
 
-<!-- Main layout: header stays at the top, member list fills the remaining space and scrolls -->
+<!-- Root: full-height column; header fixed style, list grows and scrolls -->
 <div class="card">
   <header class="header">
     <span class="group-name">{headerCountLabel}</span>
@@ -95,8 +96,8 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: var(--spacing-md);
-      padding: 1rem 1.5rem;
+      gap: 0.875rem;
+      padding: 1rem 1.25rem;
       background: hsl(292.04deg 45.75% 51.57%);
       color: var(--grey-600);
     }
@@ -107,12 +108,15 @@
       align-items: center;
       justify-content: center;
       min-height: 3rem;
-      padding: 0.35rem 1.15rem;
-      border-radius: var(--radius-xl);
+      padding: 0 1.4rem;
+      border-radius: 1.1rem;
       background: var(--background-color-primary);
-      font-size: 1rem;
+      font-size: 1.2rem;
       font-weight: 700;
       line-height: 1.1;
+      color: #3b404c;
+      letter-spacing: 0.01em;
+      white-space: nowrap;
     }
 
     /* Same look for `<a>` and `<button>`; keyboard users get a clear focus ring on the link */
@@ -123,16 +127,17 @@
       justify-content: center;
       gap: 0.5rem;
       border: none;
-      border-radius: var(--radius-xl);
+      border-radius: 1.1rem;
       min-height: 3rem;
-      padding: 0.35rem 1rem;
+      padding: 0 1rem;
       background: var(--background-color-primary);
-      color: var(--grey-500);
+      color: #6f7684;
       font: inherit;
-      font-size: 1rem;
+      font-size: 1.2rem;
       font-weight: 700;
       cursor: pointer;
       text-decoration: none;
+      white-space: nowrap;
 
       &::before {
         content: '';

--- a/src/lib/components/groups/GroupMemberCard.svelte
+++ b/src/lib/components/groups/GroupMemberCard.svelte
@@ -16,6 +16,8 @@
     groupId = '',
     onBack,
     groupName = '',
+    memberCount = 0,
+    memberLimit = null,
     /** @type {MemberRow[]} */
     members = []
   } = $props()
@@ -27,12 +29,17 @@
         ? `${resolve('/groups')}#group-${groupId}`
         : ''
   )
+
+  const currentMembers = $derived(memberCount || members.length)
+  const headerCountLabel = $derived(
+    memberLimit != null ? `${currentMembers} of ${memberLimit} members` : `${currentMembers} members`
+  )
 </script>
 
-<!-- Root: full-height column; header fixed style, list grows and scrolls -->
+<!-- Main layout: header stays at the top, member list fills the remaining space and scrolls -->
 <div class="card">
   <header class="header">
-    <span class="group-name">{groupName || 'Unnamed group'}</span>
+    <span class="group-name">{headerCountLabel}</span>
     {#if onBack}
       <button type="button" class="back" onclick={onBack}>Back</button>
     {:else if backHref}
@@ -47,18 +54,27 @@
   <ul class="members" aria-label="Group members">
     {#each members as member (member.id)}
       <li class="row">
-        <img
-          class="avatar"
-          src={member.avatarUrl}
-          alt={`Avatar of ${member.name}`}
-          width="32"
-          height="32"
-          decoding="async"
-        />
-        <div class="meta">
-          <span class="name">{member.name}</span>
-          <span class="role">{member.role}</span>
+        <div class="member-main">
+          <img
+            class="avatar"
+            src={member.avatarUrl}
+            alt={`Avatar of ${member.name}`}
+            width="32"
+            height="32"
+            decoding="async"
+          />
+          <div class="meta">
+            <span class="name">{member.name}</span>
+            {#if member.role}
+              <span class="role">{member.role}</span>
+            {/if}
+          </div>
         </div>
+        {#if member.role !== 'Super Admin'}
+          <button type="button" class="remove-member" aria-label={`Remove ${member.name} from group`}>
+            <span aria-hidden="true"></span>
+          </button>
+        {/if}
       </li>
     {:else}
       <li class="row empty">No members in this group yet.</li>
@@ -80,17 +96,24 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: var(--spacing-sm);
-      padding: var(--spacing-md) var(--spacing-lg);
+      gap: var(--spacing-md);
+      padding: 1rem 1.5rem;
       background: hsl(292.04deg 45.75% 51.57%);
-      color: var(--font-color-card);
+      color: var(--grey-600);
     }
 
-    /* Group title in the purple bar */
+    /* Count badge in the purple bar */
     & .group-name {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 3rem;
+      padding: 0.35rem 1.15rem;
+      border-radius: var(--radius-xl);
+      background: var(--background-color-primary);
       font-size: 1rem;
       font-weight: 700;
-      line-height: 1.25;
+      line-height: 1.1;
     }
 
     /* Same look for `<a>` and `<button>`; keyboard users get a clear focus ring on the link */
@@ -99,16 +122,27 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
+      gap: 0.5rem;
       border: none;
-      border-radius: var(--radius-md);
-      padding: 0.5rem 0.75rem;
+      border-radius: var(--radius-xl);
+      min-height: 3rem;
+      padding: 0.35rem 1rem;
       background: var(--background-color-primary);
-      color: hsl(263, 70%, 50%);
+      color: var(--grey-500);
       font: inherit;
-      font-size: 0.75rem;
+      font-size: 1rem;
       font-weight: 700;
       cursor: pointer;
       text-decoration: none;
+
+      &::before {
+        content: '';
+        width: 0.5rem;
+        height: 0.5rem;
+        border-left: 0.15rem solid currentColor;
+        border-bottom: 0.15rem solid currentColor;
+        transform: rotate(45deg);
+      }
 
       &:is(a):focus-visible,
       &:focus-visible {
@@ -131,7 +165,8 @@
     & .row {
       display: flex;
       align-items: center;
-      gap: var(--spacing-sm);
+      justify-content: space-between;
+      gap: var(--spacing-md);
       padding: var(--spacing-sm) var(--spacing-lg);
       border-bottom: 1px solid var(--grey-100);
 
@@ -149,11 +184,19 @@
       }
     }
 
+    & .member-main {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-md);
+      min-width: 0;
+      flex: 1;
+    }
+
     /* Square image cropped to a circle; grey background shows while the image loads */
     & .avatar {
       flex-shrink: 0;
-      width: 2rem;
-      height: 2rem;
+      width: 3rem;
+      height: 3rem;
       border-radius: var(--radius-full);
       object-fit: cover;
       object-position: center;
@@ -170,15 +213,34 @@
 
     /* Member display name */
     & .name {
-      font-size: 1rem;
-      font-weight: 500;
-      color: var(--grey-700);
+      font-size: 1.25rem;
+      font-weight: 700;
+      color: var(--grey-600);
     }
 
     /* Role / status line, slightly smaller and muted */
     & .role {
-      font-size: 0.75rem;
-      color: var(--grey-400);
+      font-size: 1rem;
+      color: var(--grey-500);
+    }
+
+    & .remove-member {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      height: 2rem;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+
+      span {
+        display: inline-block;
+        width: 1.5rem;
+        height: 0.5rem;
+        border-radius: var(--radius-full);
+        background: hsl(358, 84%, 56%);
+      }
     }
   }
 </style>

--- a/src/lib/components/groups/GroupMemberCard.svelte
+++ b/src/lib/components/groups/GroupMemberCard.svelte
@@ -15,7 +15,6 @@
   let {
     groupId = '',
     onBack,
-    groupName = '',
     memberCount = 0,
     memberLimit = null,
     /** @type {MemberRow[]} */

--- a/src/lib/components/groups/UserSectionDropdown.svelte
+++ b/src/lib/components/groups/UserSectionDropdown.svelte
@@ -6,7 +6,7 @@
   export let members = [];
 </script>
 
-<section>
+<section class="members-dropdown-panel">
   <h2 class="title">Group members details</h2>
   <!-- TODO: Replace this static member list with dynamic data from the group members. -->
    <ul>

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -82,7 +82,7 @@ export async function getGroupMembers(groupId) {
     userId: member.user_id?.id,
     email: member.user_id?.email ?? '',
     name: member.user_id?.name || member.user_id?.email || 'Unknown',
-    role: member.member_role ?? 'vistar',
+    role: member.member_role ?? 'Vistar',
     joinedAt: member.joined_at
   }))
 }

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -54,7 +54,7 @@ export async function fetchGroups() {
  */
 export async function getGroupMembers(groupId) {
   // Dot notation fetches nested fields from the user_id M2O relation
-  const url = `${DIRECTUS_URL}/items/footguard_group_members?filter[workgroup_id][_eq]=${groupId}&filter[membership_status][_eq]=active&fields=id,user_id.id,user_id.email,user_id.name,joined_at`
+  const url = `${DIRECTUS_URL}/items/footguard_group_members?filter[workgroup_id][_eq]=${groupId}&filter[membership_status][_eq]=active&fields=id,user_id.id,user_id.email,user_id.name,member_role,joined_at`
   let response
   try {
     response = await fetch(url, {
@@ -82,6 +82,7 @@ export async function getGroupMembers(groupId) {
     userId: member.user_id?.id,
     email: member.user_id?.email ?? '',
     name: member.user_id?.name || member.user_id?.email || 'Unknown',
+    role: member.member_role ?? 'vistar',
     joinedAt: member.joined_at
   }))
 }

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -74,10 +74,10 @@
     }
 
     .groups-cards {
-      display: flex;
-      flex-wrap: wrap;
+      display: grid;
+      grid-template-columns: 1fr;
       gap: var(--spacing-lg);
-      justify-content: flex-start;
+      align-items: start;
     }
    .groups-status {
       color: var(--grey-500);
@@ -90,10 +90,22 @@
     }
   }
 
-  @container groups-page (min-width: 48rem) {
+  @container groups-page (min-width: 60rem) {
     .groups-page {
       padding-top: var(--spacing-2xl);
       padding-inline: var(--spacing-xl);
+    }
+  }
+
+  @media (min-width: 48rem) {
+    .groups-page .groups-cards {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 75rem) {
+    .groups-page .groups-cards {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
 </style>


### PR DESCRIPTION
## What does this change?

Resolves issue #337 

Improves the back face of the group card with real member count data, 
add  member count display.
The member role is now fetched from Directus and shown under each member's name.



## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images
<img width="940" height="528" alt="Screenshot 2026-04-22 at 10 26 41" src="https://github.com/user-attachments/assets/31d0da54-ba2a-42ce-873c-1cbe603b8423" />



## How to review

1. open this branch and open the groups page
2. Flip a group card  the header should show member count.
3. Check each member row shows their role below their name
4. Check Directus to confirm member_role is being fetched correctly 
   for each member
