### PR TITLE
docs: add CI/CD and testing workflow to handover. #242

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -65,7 +65,6 @@ Op dit moment gebeurt dit beoordelingsproces grotendeels via Excel, wat onoverzi
   Dit zorgt ervoor dat fouten vroegtijdig worden ontdekt en dat de codebase consistent blijft tussen verschillende developers.
   De pipeline draait automatisch en geeft feedback (pass/fail), zodat alleen werkende code gemerged wordt.
 
-
 ## Wat is nog niet af?
 
 - **Datamodel**

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -56,6 +56,16 @@ Op dit moment gebeurt dit beoordelingsproces grotendeels via Excel, wat onoverzi
   - `dev` branch werkt met feature branches. Deze worden gemaakt vanaf de dev en ook hiernaartoe gemerched. De `main` branch wordt **niet** zomaar naar gemerched zonder volledige testing.
   - FDND Agency conventies worden gevolgd.
 
+- **CI/CD & Kwaliteitscontrole**
+  Binnen dit project wordt gebruik gemaakt van een CI/CD pipeline om de codekwaliteit te waarborgen.
+  De pipeline voert automatisch controles uit bij elke push en pull request, waaronder:
+- Linting (ESLint) -> controle op codekwaliteit en consistentie
+- Formatting (Prettier) -> automatische code-opmaak
+- Automated tests -> uitvoeren van unit en integration tests
+  Dit zorgt ervoor dat fouten vroegtijdig worden ontdekt en dat de codebase consistent blijft tussen verschillende developers.
+  De pipeline draait automatisch en geeft feedback (pass/fail), zodat alleen werkende code gemerged wordt.
+
+
 ## Wat is nog niet af?
 
 - **Datamodel**


### PR DESCRIPTION
## What does this change?

Resolves issue #1337

Adds documentation about the CI/CD pipeline to the handover.  
The pipeline includes ESLint, Prettier, and automated tests to ensure code quality and consistency.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] Documentation reviewed
- [x] CI/CD pipeline already running in project

## Images



## How to review

1. Open the handover document  
2. Check the new "CI/CD & Kwaliteitscontrole" section  
3. Verify that the pipeline description is clear and complete  
