### PR TITLE
fix: show dynamic group image in GroupCardHeader instead of static fa…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,4 @@ jobs:
         env:
           DIRECTUS_URL: ${{ secrets.DIRECTUS_URL }}
           DIRECTUS_TOKEN: ${{ secrets.DIRECTUS_TOKEN }}
+          PUBLIC_DIRECTUS_URL: ${{ secrets.PUBLIC_DIRECTUS_URL }}

--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -36,6 +36,7 @@
   const faceIdSuffix = $derived(String(group?.id ?? "unknown"));
   const frontFaceId = $derived(`group-${faceIdSuffix}`);
   const membersFaceId = $derived(`group-${faceIdSuffix}-members`);
+  const groupImage = $derived(group?.image ?? null);
 
   const membersForBackFace = $derived(
     members.map((m) => ({
@@ -61,6 +62,7 @@
             name={groupName}
             status={groupStatus}
             conditionLabel={conditionLabel}
+            image={groupImage}
           />
           <SwitchSidesButton label="Members" onclick={flipToMembers} />
         </div>

--- a/src/lib/components/groups/GroupCardHeader.svelte
+++ b/src/lib/components/groups/GroupCardHeader.svelte
@@ -1,21 +1,27 @@
 <script>
   import groupHeaderPhoto from "$lib/assets/img/charcot-icon.webp";
+  import { PUBLIC_DIRECTUS_URL } from '$env/static/public'
+
 
   // Dynamic group data passed from GroupCard.svelte
   export let name;
   export let status;
   export let conditionLabel;
+  export let image;
 
   // Fallback values keep the header safe while API data is still incomplete
   $: groupName = name ?? "Unnamed group";
   $: groupStatus = status ?? "Unknown";
   $: groupConditionLabel = conditionLabel ?? "General";
+  $: groupImage = image 
+  ? `${PUBLIC_DIRECTUS_URL}/assets/${image}` 
+  : groupHeaderPhoto;
 </script>
 
 <section>
   <div class="header-photo">
     <!-- TODO: Replace static header image with group avatar from dynamic group data. -->
-    <img src={groupHeaderPhoto} alt="Group icon" />
+    <img src={groupImage} alt="Group icon" />
   </div>
   <h2>{groupName}</h2>
   <ul>

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -14,7 +14,7 @@ function buildDirectusAssetUrl(fileId) {
  * @throws {Error} If the API call fails
  */
 export async function fetchGroups() {
-  const groupsUrl = `${DIRECTUS_URL}/items/footguard_workgroups?fields=id,group_name,status,condition_label,created_by_user_id`
+  const groupsUrl = `${DIRECTUS_URL}/items/footguard_workgroups?fields=id,group_name,status,condition_label,created_by_user_id,image`
   const membersUrl = `${DIRECTUS_URL}/items/footguard_group_members?fields=id,workgroup_id,member_role,membership_status,user_id.id,user_id.name,user_id.email,user_id.photo&filter[membership_status][_eq]=active&limit=-1`
 
   let groupsResponse
@@ -79,7 +79,8 @@ export async function fetchGroups() {
       status: group.status,
       conditionlabel: group.condition_label ?? 'General', // fallback if null
       members,
-      memberCount: members.length
+      memberCount: members.length,
+      image: group.image ?? null
     }
   })
 }


### PR DESCRIPTION

## What does this change?

Resolves issue #353 

All group cards were showing the same static fallback image (`charcot-icon.webp`) instead of the unique image stored per group in Directus. This PR fixes the full data flow so each group card displays its own image from the `footguard_workgroups` collection.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

On `dev`, go to the groups page and notice all group cards show the same static image.
On this branch, go to the groups page and each group card should display its own unique image as uploaded in Directus under `footguard_workgroups`.
