### PR TITLE
 feat :extract RemoveMemberButton component #355

### DIFF
--- a/src/lib/components/groups/GroupMemberCard.svelte
+++ b/src/lib/components/groups/GroupMemberCard.svelte
@@ -5,6 +5,7 @@
    */
 
   // Builds correct app URLs when the site uses a base path (SvelteKit `resolve`).
+  import RemoveMemberButton from './RemoveMemberButton.svelte'
   import { resolve } from '$app/paths'
 
   /**
@@ -71,9 +72,7 @@
           </div>
         </div>
         {#if member.role !== 'Super Admin'}
-          <button type="button" class="remove-member" aria-label={`Remove ${member.name} from group`}>
-            <span aria-hidden="true"></span>
-          </button>
+          <RemoveMemberButton memberId={member.id} />
         {/if}
       </li>
     {:else}
@@ -228,23 +227,5 @@
       color: var(--grey-500);
     }
 
-    & .remove-member {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 2rem;
-      height: 2rem;
-      border: none;
-      background: transparent;
-      cursor: pointer;
-
-      span {
-        display: inline-block;
-        width: 1.5rem;
-        height: 0.5rem;
-        border-radius: var(--radius-full);
-        background: hsl(358, 84%, 56%);
-      }
-    }
   }
 </style>

--- a/src/lib/components/groups/GroupMemberCard.svelte
+++ b/src/lib/components/groups/GroupMemberCard.svelte
@@ -16,7 +16,6 @@
   let {
     groupId = '',
     onBack,
-    groupName = '',
     memberCount = 0,
     memberLimit = null,
     /** @type {MemberRow[]} */

--- a/src/lib/components/groups/RemoveMemberButton.svelte
+++ b/src/lib/components/groups/RemoveMemberButton.svelte
@@ -1,0 +1,49 @@
+<script>
+  /**
+   * RemoveMemberButton component
+   * Submits the remove action for a single member record.
+   * Uses SvelteKit form enhancement so the page URL does not visibly change.
+   */
+  import { enhance } from '$app/forms'
+
+  /** @type {string|number} - footguard_group_members record id */
+  export let memberId
+</script>
+
+<!-- Named action: remove this member from the current group -->
+<form method="POST" action="?/remove" use:enhance>
+  <!-- Hidden id sent to +page.server.js actions.remove -->
+  <input type="hidden" name="memberId" value={memberId} />
+  <button type="submit" class="btn-remove" aria-label="Remove member">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M19 13H5v-2h14v2z" />
+    </svg>
+  </button>
+</form>
+
+<style>
+  .btn-remove {
+    border: none;
+    background: var(--grey-100);
+    color: var(--grey-500);
+    border-radius: var(--radius-full);
+    width: 1.75rem;
+    height: 1.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background var(--transition-fast), color var(--transition-fast);
+
+    svg {
+      width: 1rem;
+      height: 1rem;
+    }
+
+    &:hover {
+      background: var(--grey-200);
+      color: var(--grey-700);
+    }
+  }
+</style>

--- a/src/lib/components/groups/RemoveMemberButton.svelte
+++ b/src/lib/components/groups/RemoveMemberButton.svelte
@@ -42,8 +42,8 @@
     }
 
     &:hover {
-      background: var(--grey-200);
-      color: var(--grey-700);
+      background: var(--red-500, #ef4444);
+      color: var(--grey-50, #ffffff);
     }
   }
 </style>

--- a/src/lib/components/groups/UserSectionDropdown.svelte
+++ b/src/lib/components/groups/UserSectionDropdown.svelte
@@ -1,5 +1,6 @@
 <script>
   import fallbackAvatar from '$lib/assets/img/profile-avatar.webp';
+  import RemoveMemberButton from './RemoveMemberButton.svelte';
 
   // Members are passed from GroupCard.svelte
   // Each member can have: id, name, email, isEmpty (open slot)
@@ -19,16 +20,7 @@
           <span class="member-role">{member.role ?? 'No role assigned'}</span>
         </div>
 
-        <!-- Remove button: grey circle with minus icon only — no text, no red -->
-        <form method="POST" action="?/remove">
-          <input type="hidden" name="memberId" value={member.id} />
-          <button type="submit" class="btn-remove" aria-label="Remove member">
-            <!-- Minus icon inside the button -->
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M19 13H5v-2h14v2z"/>
-            </svg>
-          </button>
-        </form>
+        <RemoveMemberButton memberId={member.id} />
       </li>
     {/each}
 
@@ -93,44 +85,6 @@ li {
     line-height: 1.2;
     text-align: left;
   }
-
-  /* Remove button: grey circle background with minus icon — no red */
-  .btn-remove {
-    border: none;
-    background: var(--grey-100);
-    color: var(--grey-500);
-    border-radius: var(--radius-full);
-    width: 1.75rem;
-    height: 1.75rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    flex-shrink: 0;
-    transition: background var(--transition-fast);
-
-    svg {
-      width: 1rem;
-      height: 1rem;
-    }
-
-    /* Slightly darker grey on hover */
-    &:hover {
-      background: var(--red-200);
-      color: var(--grey-700);
-    }
-  }
-
-  .btn-remove svg {
-    width: 1rem;
-    height: 1rem;
-  }
-
-  /* Slightly darker on hover — still no red */
-  .btn-remove:hover {
-    color: var(--red-600);
-  }
-
   /* Fallback empty state message */
   .empty-state {
     display: block;

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -175,8 +175,9 @@ export async function findUserByEmail(email) {
  * @throws {Error} If the user is already a member or the API call fails
  */
 export async function addUserToGroup(groupId, userId, addedByUserId, userRole) {
-  // Step 1: Check if this user is already an active member of this group
-  const checkUrl = `${DIRECTUS_URL}/items/footguard_group_members?filter[workgroup_id][_eq]=${Number(groupId)}&filter[user_id][_eq]=${Number(userId)}&limit=1`
+  // Step 1: Check all existing membership records for this group + user pair.
+  // We include membership_status so we can distinguish active vs inactive records.
+  const checkUrl = `${DIRECTUS_URL}/items/footguard_group_members?filter[workgroup_id][_eq]=${Number(groupId)}&filter[user_id][_eq]=${Number(userId)}&fields=id,membership_status&limit=-1`
 
   let checkResponse
   try {
@@ -199,12 +200,59 @@ export async function addUserToGroup(groupId, userId, addedByUserId, userRole) {
 
   const checkJson = await checkResponse.json()
 
-  // Block adding a user who is already a member of this group
-  if (checkJson.data.length > 0) {
+  // Normalize API response to a safe array.
+  const existingRecords = checkJson.data ?? []
+  const activeRecord = existingRecords.find(
+    (record) => record?.membership_status?.toLowerCase?.() === 'active'
+  )
+
+  // If there is already an active membership row, block duplicate adds.
+  if (activeRecord) {
     throw new Error('This user is already a member of this group.')
   }
 
-  // Step 2: Create the member record
+  // Step 2: If an inactive membership row exists, reactivate it
+  // instead of creating a second row for the same user/group.
+  const inactiveRecord = existingRecords.find(
+    (record) => record?.membership_status?.toLowerCase?.() !== 'active'
+  )
+
+  if (inactiveRecord?.id) {
+    // Reactivate the existing row and refresh key fields.
+    const reactivateUrl = `${DIRECTUS_URL}/items/footguard_group_members/${Number(inactiveRecord.id)}`
+
+    let reactivateResponse
+    try {
+      reactivateResponse = await fetch(reactivateUrl, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${DIRECTUS_TOKEN}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          membership_status: 'active',
+          member_role: userRole ?? 'Viewer',
+          joined_at: new Date().toISOString(),
+          updated_by_user_id: addedByUserId ? Number(addedByUserId) : null
+        })
+      })
+    } catch (networkError) {
+      throw new Error(`Network error while reactivating member: ${networkError.message}`)
+    }
+
+    if (!reactivateResponse.ok) {
+      const errorBody = await reactivateResponse.text()
+      throw new Error(
+        `Directus API error while reactivating member: ${reactivateResponse.status} - ${errorBody}`
+      )
+    }
+
+    // Return the reactivated member row.
+    const reactivateJson = await reactivateResponse.json()
+    return reactivateJson.data
+  }
+
+  // Step 3: No prior row exists, so create a brand new active membership row.
   const createUrl = `${DIRECTUS_URL}/items/footguard_group_members`
 
   let createResponse
@@ -237,4 +285,42 @@ export async function addUserToGroup(groupId, userId, addedByUserId, userRole) {
 
   const createJson = await createResponse.json()
   return createJson.data
+}
+
+/**
+ * Soft-removes a member from a workgroup by setting membership_status to inactive.
+ *
+ * @param {string|number} memberId - The footguard_group_members record ID
+ * @param {string|number|null} updatedByUserId - The admin performing the action
+ * @returns {Promise<object>} The updated member record
+ * @throws {Error} If the API call fails
+ */
+export async function removeMemberFromGroup(memberId, updatedByUserId = null) {
+  // Soft remove: keep the row for audit/history and set status to inactive.
+  const url = `${DIRECTUS_URL}/items/footguard_group_members/${Number(memberId)}`
+
+  let response
+  try {
+    response = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${DIRECTUS_TOKEN}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        membership_status: 'inactive',
+        updated_by_user_id: updatedByUserId ? Number(updatedByUserId) : null
+      })
+    })
+  } catch (networkError) {
+    throw new Error(`Network error while removing member: ${networkError.message}`)
+  }
+
+  if (!response.ok) {
+    const errorBody = await response.text()
+    throw new Error(`Directus API error while removing member: ${response.status} - ${errorBody}`)
+  }
+
+  const json = await response.json()
+  return json.data
 }

--- a/src/routes/groups/+page.server.js
+++ b/src/routes/groups/+page.server.js
@@ -2,7 +2,13 @@
 // Fetches workgroup data from Directus before the page renders.
 // The API token stays secure because this code only runs on the server.
 
-import { fetchGroups, findUserByEmail, addUserToGroup } from '$lib/server/groups.js'
+import {
+  fetchGroups,
+  findUserByEmail,
+  addUserToGroup,
+  getGroupMembers,
+  removeMemberFromGroup
+} from '$lib/server/groups.js'
 import { error, fail } from '@sveltejs/kit'
 
 /** @type {import('./$types').PageServerLoad} */
@@ -10,9 +16,22 @@ export async function load() {
   try {
     const groups = await fetchGroups()
 
+    // Fetch members for each group in parallel.
+    const groupsWithMembers = await Promise.all(
+      groups.map(async (group) => {
+        try {
+          const members = await getGroupMembers(group.id)
+          return { ...group, members, memberCount: members.length }
+        } catch {
+          // If members fail for one group, keep page functional for others.
+          return { ...group, members: [], memberCount: 0 }
+        }
+      })
+    )
+
     // Pass groups (with their members) to +page.svelte via the data prop
     return {
-      groups,
+      groups: groupsWithMembers,
       loadError: null
     }
   } catch {
@@ -24,21 +43,16 @@ export async function load() {
 export const actions = {
   /**
    * Handles adding an existing Directus user to a group by email.
-   * The admin types an email → we find the user → we add them directly.
-   * No email is sent, no pending step — the user is immediately a member.
-   *
-   * Steps:
-   * 1. Validate email and groupId
-   * 2. Look up the user in Directus by email via findUserByEmail()
-   * 3. Add their user_id to footguard_group_members via addUserToGroup()
+   * The user is added directly as an active member (no invite email step).
    *
    * @type {import('./$types').Actions}
    */
   addMember: async ({ request, locals }) => {
     const data = await request.formData()
+    const currentUserId = locals.user?.id ?? null
     const email = data.get('email')?.toString().trim()
     const groupId = data.get('groupId')?.toString()
-    const addedByUserId = locals.user?.id ?? null
+    const addedByUserId = currentUserId
 
     // --- Validation: check that both fields are present ---
     if (!email || !groupId) {
@@ -103,6 +117,31 @@ export const actions = {
       return fail(500, {
         groupId,
         error: err.message || 'Failed to add member. Please try again.'
+      })
+    }
+  },
+
+  /**
+   * Handles removing a member from a group.
+   * This performs a soft remove by setting membership_status to "inactive".
+   *
+   * @type {import('./$types').Actions}
+   */
+  remove: async ({ request, locals }) => {
+    const data = await request.formData()
+    const memberId = data.get('memberId')?.toString()
+    const updatedByUserId = locals.user?.id ?? null
+
+    if (!memberId) {
+      return fail(400, { error: 'Member ID is required.' })
+    }
+
+    try {
+      await removeMemberFromGroup(memberId, updatedByUserId)
+      return { success: true, removedMemberId: memberId }
+    } catch (err) {
+      return fail(500, {
+        error: err.message || 'Failed to remove member. Please try again.'
       })
     }
   }


### PR DESCRIPTION
## What does this change?

Resolves issue #355 

1. RemoveMemberButton extracted the remove button was duplicated 
   inline in GroupMemberCard and UserSectionDropdown. It's now a single 
   reusable component with form enhancement so removal happens without 
   a full page reload.

2. Soft member removal members are not deleted from Directus. 
   The membership_status is set to inactive, keeping the row for 
   audit and history. Re-adding the same user reactivates the existing 
   row instead of creating a duplicate.

3. Members loaded on page the groups page now fetches members 
   for all groups in parallel on load, so GroupMemberCard always has 
   real data when the card flips.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images


<img width="486" height="748" alt="Screenshot 2026-04-23 at 16 36 55" src="https://github.com/user-attachments/assets/05584ef0-8183-4e60-ae21-e8220c6681ab" />
<img width="486" height="748" alt="Screenshot 2026-04-23 at 16 37 01" src="https://github.com/user-attachments/assets/5ef26ad5-a6e8-467a-8984-b0122265bd0b" />



## How to review

1. Pull the branch and open the groups page
2. Flip a group card — member list should populate with real data
3. Click the remove button on a non-admin member,  member should 
   disappear from the list.
4. Re-add the same member via the invite form — they should reappear; 
5. Confirm Super Admin rows have no remove button.
