### PR TITLE
337 feat: users avatar/Role-based sort members member card

### DIFF
--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -38,13 +38,32 @@
   const membersFaceId = $derived(`group-${faceIdSuffix}-members`);
   const groupImage = $derived(group?.image ?? null);
 
+  // make clear order for roles in back face list
+  // first super admin, then admin, then assessor, then viewer
+  const rolePriority = {
+    'super admin': 0,
+    admin: 1,
+    assessor: 2,
+    viewer: 3,
+    vister: 3
+  };
+
+  // if role not known keep it in the end
+  function getRolePriority(role) {
+    const normalizedRole = String(role ?? "").trim().toLowerCase();
+    return rolePriority[normalizedRole] ?? 99;
+  }
+
   const membersForBackFace = $derived(
-    members.map((m) => ({
-      id: m.id,
-      name: m.name,
-      role: m.role,
-      avatarUrl: m.avatarUrl ?? previewAvatarFallback
-    }))
+    [...members]
+      // sort members by role order we need in design
+      .sort((a, b) => getRolePriority(a?.role) - getRolePriority(b?.role))
+      .map((m) => ({
+        id: m.id,
+        name: m.name,
+        role: m.role,
+        avatarUrl: m.avatarUrl ?? previewAvatarFallback
+      }))
   );
 
   const isPlural = $derived(memberCount !== 1);

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -96,7 +96,7 @@ export async function fetchGroups() {
  */
 export async function getGroupMembers(groupId) {
   // Dot notation fetches nested fields from the user_id M2O relation
-  const url = `${DIRECTUS_URL}/items/footguard_group_members?filter[workgroup_id][_eq]=${groupId}&filter[membership_status][_eq]=active&fields=id,user_id.id,user_id.email,user_id.name,member_role,joined_at`
+  const url = `${DIRECTUS_URL}/items/footguard_group_members?filter[workgroup_id][_eq]=${groupId}&filter[membership_status][_eq]=active&fields=id,user_id.id,user_id.email,user_id.name,user_id.photo,member_role,joined_at`
   let response
   try {
     response = await fetch(url, {
@@ -124,6 +124,7 @@ export async function getGroupMembers(groupId) {
     userId: member.user_id?.id,
     email: member.user_id?.email ?? '',
     name: member.user_id?.name || member.user_id?.email || 'Unknown',
+    avatarUrl: buildDirectusAssetUrl(member.user_id?.photo),
     role: member.member_role ?? 'Vistar',
     joinedAt: member.joined_at
   }))


### PR DESCRIPTION
## What does this change?

Resolves issue #337 

Two small improvements to the group member back face:

1. Real avatars  included in the Directus members query and mapped to `avatarUrl` so each member row shows 
   their actual profile photo instead of the placeholder.

2. Role-based sort members on the back face are now ordered by role: Super Admin first, then Admin, Assessor, and Viewer. Unknown roles are pushed to the end.



## How Has This Been Tested?


- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images
### Befor:
<img width="486" height="748" alt="Screenshot 2026-04-23 at 16 37 01" src="https://github.com/user-attachments/assets/45c66314-39dd-4ece-8b54-ba124449956a" />

<hr>
<hr>

### After:

<img width="486" height="748" alt="Screenshot 2026-04-23 at 17 58 16" src="https://github.com/user-attachments/assets/b2682832-38d3-4802-bd79-018682fac205" />




## How to review

1. Pull the branch and flip a group card
2. Members should show their real profile photo not the placeholder
3. Check the order: Super Admin should always appear first, followed by Admin, Assessor, then Viewer
4. Add a member with an unknown role and confirm they appear at the bottom of the list