### PR TITLE
262 user story make profile page responsive across all devices

### DIFF
--- a/src/lib/components/profile/ProfileHero.svelte
+++ b/src/lib/components/profile/ProfileHero.svelte
@@ -174,7 +174,8 @@
     }
   }
 
-  @container profile-card (min-width: 42rem) {
+  /* tablet layout */
+  @container profile-card (min-width: 42rem) and (max-width: 63.99rem) {
     .profile-hero {
       padding: 0 0 var(--spacing-xl);
 
@@ -193,6 +194,30 @@
       .profile-info {
         margin-top: 4rem;
         padding-inline: var(--spacing-lg);
+      }
+    }
+  }
+
+  /* desktop layout */
+  @container profile-card (min-width: 64rem) {
+    .profile-hero {
+      padding: 0 0 var(--spacing-2xl);
+
+      &::before {
+        min-height: 11rem;
+        border-radius: 0;
+      }
+
+      .avatar-wrap {
+        .profile-avatar {
+          width: 7.5rem;
+          height: 7.5rem;
+        }
+      }
+
+      .profile-info {
+        margin-top: 4.25rem;
+        padding-inline: var(--spacing-xl);
       }
     }
   }

--- a/src/lib/components/profile/ProfileInfo.svelte
+++ b/src/lib/components/profile/ProfileInfo.svelte
@@ -117,13 +117,27 @@
 
   }
 
-  @container profile-card (min-width: 42rem) {
+  /* tablet layout */
+  @container profile-card (min-width: 42rem) and (max-width: 63.99rem) {
     .profile-general-info {
       padding: 0 var(--spacing-lg) var(--spacing-2xl);
 
       .info-grid {
         grid-template-columns: 1fr 1fr;
         column-gap: var(--spacing-lg);
+        row-gap: var(--spacing-lg);
+      }
+    }
+  }
+
+  /* desktop layout */
+  @container profile-card (min-width: 64rem) {
+    .profile-general-info {
+      padding: 0 var(--spacing-xl) var(--spacing-2xl);
+
+      .info-grid {
+        grid-template-columns: 1fr 1fr;
+        column-gap: var(--spacing-xl);
         row-gap: var(--spacing-lg);
       }
     }

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -245,12 +245,25 @@
     }
   }
 
-  @media (min-width: 42rem) {
+  /* tablet layout */
+  @media (min-width: 42rem) and (max-width: 63.99rem) {
     .profile-page {
       padding: var(--spacing-xl);
 
       .profile-card {
         max-width: 100%;
+        margin-inline: auto;
+      }
+    }
+  }
+
+  /* desktop layout */
+  @media (min-width: 64rem) {
+    .profile-page {
+      padding: var(--spacing-2xl) var(--spacing-xl);
+
+      .profile-card {
+        max-width: 72rem;
         margin-inline: auto;
       }
     }


### PR DESCRIPTION
## What does this change?


Resolves issue #262

The profile page previously had only mobile and tablet breakpoints. 
On wide screens the card stretched too far and the info grid stayed single-column. This PR adds a desktop layout at 64rem+ and tightens the tablet range so styles don't bleed into each other.

[livesite](https://livesite.com)

## How Has This Been Tested?
Link to [Wiki](https://github.com/fdnd-agency/footguard/wiki/Profile-page-RAPPE) test.

- [x] [User test]()
- [x] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images
<img width="403" height="748" alt="Screenshot 2026-04-23 at 18 17 25" src="https://github.com/user-attachments/assets/a15af825-e2a8-4f41-96aa-ecd38b712845" />

<img width="476" height="700" alt="Screenshot 2026-04-23 at 18 18 41" src="https://github.com/user-attachments/assets/564576b1-710a-4e52-9198-3e0e8d4000bd" />
<img width="772" height="458" alt="Screenshot 2026-04-23 at 18 21 00" src="https://github.com/user-attachments/assets/5d0327a1-160e-4e13-9484-57f16fa548ef" />
<img width="783" height="833" alt="Screenshot 2026-04-23 at 18 29 32" src="https://github.com/user-attachments/assets/c2df1760-7a3d-4f02-a4dd-045f2479db9b" />



## How to review

1.Open the profile page in the browser
2. Resize across mobile, tablet (42–63.99rem), and desktop (64rem+) and check for any layout issues or style overlap
3. At 64rem+ the card should be centered with a max-width of 72rem
4. At 64rem+ the info grid should display in 2 columns
5. At 42–63.99rem the tablet layout should look the same as before
6. At mobile width nothing should look different from before
