### PR TITLE
359 feat: add group theme colors, rename members to assessors, flip dropdown

### DIFF
--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -87,7 +87,7 @@
         </div>
 
         <section class="members-section">
-          <h2 class="title">Members</h2>
+          <h2 class="title">Assessors</h2>
 
           <!-- Member avatar preview row with add button -->
           <div class="members-preview">
@@ -127,7 +127,7 @@
 
         <details>
           <summary>
-            <span>{memberCount} member{isPlural ? "s" : ""}</span>
+            <span>{memberCount} Assessor{isPlural ? "s" : ""}</span>
             <span class="chevron">
               <DetailsUpIcon />
             </span>
@@ -166,7 +166,6 @@
 
   .group-card-root:has(.face--front details[open]) {
     z-index: 30;
-    margin-bottom: 10rem;
   }
 
   .scene {
@@ -295,15 +294,15 @@
     &[open] > .members-dropdown-panel {
       display: block;
       position: absolute;
-      top: 100%;
+      bottom: 100%;
       left: 0;
       right: 0;
       z-index: 40;
-      max-height: 10rem;
+      max-height: 16rem;
       overflow-y: auto;
       background: var(--background-color-primary);
-      border-top: 1px solid var(--grey-100);
-      border-radius: 0 0 var(--radius-xl) var(--radius-xl);
+      border-bottom: 1px solid var(--grey-100);
+      border-radius: var(--radius-xl) var(--radius-xl) 0 0;
       box-shadow: none;
     }
 

--- a/src/lib/components/groups/GroupInviteForm.svelte
+++ b/src/lib/components/groups/GroupInviteForm.svelte
@@ -74,7 +74,7 @@
   </script>
 
 
-<label for="add-member-email">Add member by email</label>
+<label for="add-member-email">Add assessor by email</label>
 
 <!-- Form uses addMember action — no email is sent, user is directly added -->
 <form method="POST" action="?/addMember" use:enhance={handleSubmit}>

--- a/src/lib/components/groups/GroupMemberCard.svelte
+++ b/src/lib/components/groups/GroupMemberCard.svelte
@@ -15,12 +15,21 @@
   // With `onBack` from GroupCard, “Back” is a button (no URL change). Without it, `groupId` builds an optional hash link.
   let {
     groupId = '',
+    groupName = '',
     onBack,
     memberCount = 0,
     memberLimit = null,
     /** @type {MemberRow[]} */
     members = []
   } = $props()
+
+  const groupHeaderColor = $derived(
+    `var(--theme-${String(groupName ?? '')
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')}, var(--theme-charcot))`
+  )
 
   const backHref = $derived(
     onBack
@@ -38,7 +47,7 @@
 
 <!-- Root: full-height column; header fixed style, list grows and scrolls -->
 <div class="card">
-  <header class="header">
+  <header class="header" style={`--group-header-color: ${groupHeaderColor};`}>
     <span class="group-name">{headerCountLabel}</span>
     {#if onBack}
       <button type="button" class="back" onclick={onBack}>Back</button>
@@ -96,7 +105,7 @@
       justify-content: space-between;
       gap: 0.875rem;
       padding: 1rem 1.25rem;
-      background: hsl(292.04deg 45.75% 51.57%);
+      background: var(--group-header-color);
       color: var(--grey-600);
     }
 

--- a/src/lib/components/groups/UserSectionDropdown.svelte
+++ b/src/lib/components/groups/UserSectionDropdown.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <section class="members-dropdown-panel">
-  <h2 class="title">Group members details</h2>
+  <h2 class="title">Assessor list</h2>
   <!-- TODO: Replace this static member list with dynamic data from the group members. -->
    <ul>
     {#each members as member (member.id)}

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -281,8 +281,6 @@ a {
   margin: var(--spacing-sm);
 }
 
-
-
 .theme-charcot {
   background-color: var(--theme-charcot);
 }
@@ -310,9 +308,6 @@ a {
 .theme-wound-healing {
   background-color: var(--theme-wound-healing);
 }
-
-
-
 
 button {
   font-family: inherit;
@@ -375,9 +370,6 @@ select {
   outline: 2px solid var(--blue-500);
   outline-offset: 2px;
 }
-
-
-
 
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -139,6 +139,15 @@
   --green-200: hsl(150, 55%, 72%);
   --green-100: hsl(150, 45%, 85%);
 
+  /* Group theme colors */
+  --theme-charcot: #ae4bbd;
+  --theme-classification: #e8b809;
+  --theme-infection: #8db331;
+  --theme-prevention: #e6762c;
+  --theme-pad: #028d8f;
+  --theme-offloading: #009bcb;
+  --theme-wound-healing: #6a77dd;
+
   /* Neutral / grey */
   --grey-700: hsl(210, 12%, 15%);
   --grey-600: hsl(210, 10%, 25%);
@@ -272,6 +281,39 @@ a {
   margin: var(--spacing-sm);
 }
 
+
+
+.theme-charcot {
+  background-color: var(--theme-charcot);
+}
+
+.theme-classification {
+  background-color: var(--theme-classification);
+}
+
+.theme-infection {
+  background-color: var(--theme-infection);
+}
+
+.theme-prevention {
+  background-color: var(--theme-prevention);
+}
+
+.theme-pad {
+  background-color: var(--theme-pad);
+}
+
+.theme-offloading {
+  background-color: var(--theme-offloading);
+}
+
+.theme-wound-healing {
+  background-color: var(--theme-wound-healing);
+}
+
+
+
+
 button {
   font-family: inherit;
   border: none;
@@ -333,6 +375,9 @@ select {
   outline: 2px solid var(--blue-500);
   outline-offset: 2px;
 }
+
+
+
 
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION

## What does this change?

Resolves issue #359 #360

Two improvements:

**Assessor rename (#359)** "Members" is renamed to "Assessors" across GroupCard, GroupInviteForm, and UserSectionDropdown to match the correct domain terminology. 
The dropdown is also flipped to open upward so it doesn't get clipped at the bottom of the card.

**Group theme colors (#360)**  Each group now has its own header color on the back face. 
The color is derived from the group name using a CSS custom property lookup pattern with a fallback to --theme-charcot. 
Seven theme color tokens and utility classes are added to the style guide.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images
### Befor:

<img width="150" height="300" alt="Screenshot 2026-04-23 at 16 37 01" src="https://github.com/user-attachments/assets/d0a1d2a3-d2a2-4f5c-8c1f-810b2b7e367f" /><br>
<img width="150" height="300" alt="Screenshot 2026-04-23 at 16 36 55" src="https://github.com/user-attachments/assets/3460d9ac-e75b-44b4-b2f9-fcfdc427192a" />


<hr>
<hr>

### After:

<img width="150" height="300" alt="Screenshot 2026-04-23 at 22 03 34" src="https://github.com/user-attachments/assets/f70317ed-ec18-49ae-a7ae-d632f82b65b4" /><br>

<img width="150" height="300" alt="Screenshot 2026-04-23 at 22 03 39" src="https://github.com/user-attachments/assets/84c3ac2c-e526-463c-855c-294580ea4676" /><br>
<img width="150" height="300" alt="Screenshot 2026-04-23 at 22 03 43" src="https://github.com/user-attachments/assets/2b4aa9cc-a45d-484b-b8b6-719a8f553aa1" />



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

1. Pull the branch and open the groups page
2. Check all "Members" labels are now "Assessors" across the card, 
   dropdown, and invite form
3. Open the assessors dropdown — it should expand upward, not downward
4. Flip each group card — the back face header should show that 
   group's theme color
5. Check a group with an unrecognised name — header should fall back 
   to the charcot purple

