### PR TITLE
367 user story add new group card button

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -211,7 +211,7 @@ De Button is een herbruikbare component die consistente knoppen binnen Footguard
 
 | Prop        | Type                                              | Default   | Uitleg                                   |
 | ----------- | ------------------------------------------------- | --------- | ---------------------------------------- |
-| `variant`   | "primary" \| "secondary" \| "outline" \| "danger" | "primary" | Bepaalt de visuele stijl van de knop     |
+| `variant`   | "primary" \| "secondary" \| "outline" | "primary" | Bepaalt de visuele stijl van de knop     |
 | `size`      | "small" \| "medium" \| "large"                    | "medium"  | Regelt de afmeting van de knop           |
 | `disabled`  | boolean                                           | false     | Maakt de knop niet interactief           |
 | `fullWidth` | boolean                                           | false     | Laat de knop volledige breedte gebruiken |
@@ -226,7 +226,6 @@ De Button is een herbruikbare component die consistente knoppen binnen Footguard
 
 <button variant="secondary">Secundair</button>
 <button variant="outline">Outline</button>
-<button variant="danger">Danger</button>
 
 <button size="small">Klein</button>
 <button size="medium">Middel</button>

--- a/docs/components.md
+++ b/docs/components.md
@@ -211,7 +211,7 @@ De Button is een herbruikbare component die consistente knoppen binnen Footguard
 
 | Prop        | Type                                              | Default   | Uitleg                                   |
 | ----------- | ------------------------------------------------- | --------- | ---------------------------------------- |
-| `variant`   | "primary" \| "secondary" \| "outline" | "primary" | Bepaalt de visuele stijl van de knop     |
+| `variant`   | "primary" \| "secondary" \| "outline" \| "danger" | "primary" | Bepaalt de visuele stijl van de knop     |
 | `size`      | "small" \| "medium" \| "large"                    | "medium"  | Regelt de afmeting van de knop           |
 | `disabled`  | boolean                                           | false     | Maakt de knop niet interactief           |
 | `fullWidth` | boolean                                           | false     | Laat de knop volledige breedte gebruiken |
@@ -226,6 +226,7 @@ De Button is een herbruikbare component die consistente knoppen binnen Footguard
 
 <button variant="secondary">Secundair</button>
 <button variant="outline">Outline</button>
+<button variant="danger">Danger</button>
 
 <button size="small">Klein</button>
 <button size="medium">Middel</button>

--- a/src/lib/assets/svg/puls-icon-no-background.svelte
+++ b/src/lib/assets/svg/puls-icon-no-background.svelte
@@ -1,0 +1,21 @@
+<script>
+  export let width = 17;
+  export let height = 17;
+</script>
+
+<svg
+  {width}
+  {height}
+  viewBox="0 0 17 17"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
+>
+  <path
+    d="M8.25 1.25V15.25M1.25 8.25H15.25"
+    stroke="currentColor"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/src/lib/components/groups/AddGroupButton.svelte
+++ b/src/lib/components/groups/AddGroupButton.svelte
@@ -1,0 +1,98 @@
+<script>
+  /**
+   * Simple props:
+   * - label: text inside the button
+   * - href: go to another page
+   * - disabled: show disabled button style
+   */
+  let { label = "Create New Group", disabled = false, href = "/groups/new" } = $props();
+</script>
+
+<!-- If disabled (or no action), show non-clickable version -->
+{#if disabled || !href}
+  <span class="add-group-btn" aria-disabled="true">
+    <span class="add-group-btn__text">{label}</span>
+    <span class="add-group-btn__icon" aria-hidden="true">+</span>
+  </span>
+{:else}
+  <!-- Link-first for progressive enhancement -->
+  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+  <a class="add-group-btn" {href}>
+    <span class="add-group-btn__text">{label}</span>
+    <span class="add-group-btn__icon" aria-hidden="true">+</span>
+  </a>
+{/if}
+
+<style>
+  /* Same look for span, button, and link versions */
+  .add-group-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-lg);
+    min-width: min(100%, 20rem);
+    margin: 0;
+    appearance: none;
+    padding: var(--spacing-sm) var(--spacing-lg);
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--blue-500);
+    color: var(--background-color-primary);
+    font-family: var(--main-font);
+    font-size: clamp(14px, 2vw, 16px);
+    font-weight: 500;
+    line-height: 1.2;
+    white-space: nowrap;
+    cursor: pointer;
+    text-decoration: none;
+    transition:
+      background var(--transition-fast),
+      transform var(--transition-fast),
+      box-shadow var(--transition-fast);
+
+    &:hover:not([aria-disabled="true"]) {
+      background: var(--blue-600);
+      transform: translateY(-1px);
+      box-shadow: var(--shadow-md);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--grey-50, #fff);
+      outline-offset: 2px;
+    }
+
+    &[aria-disabled="true"],
+    &:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+      box-shadow: none;
+      transform: none;
+    }
+
+    .add-group-btn__text {
+      /* Keep long text from breaking layout */
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .add-group-btn__icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      font-size: clamp(24px, 5vw, 32px);
+      line-height: 1;
+      font-weight: 400;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .add-group-btn {
+      transition: none;
+
+      &:hover:not([aria-disabled="true"]) {
+        transform: none;
+      }
+    }
+  }
+</style>

--- a/src/lib/components/groups/AddGroupButton.svelte
+++ b/src/lib/components/groups/AddGroupButton.svelte
@@ -1,37 +1,31 @@
 <script>
+  import { resolve } from "$app/paths";
   import PulsIconNoBackground from "$lib/assets/svg/puls-icon-no-background.svelte";
 
   /**
-   * “Create new group” control for the groups page.
+   * Create-new-group control for the groups page.
    *
    * Props:
    * - label — visible text (default: “Create New Group”).
-   * - href  — where the link goes (default: /groups/new). Works without JS (real <a>).
-   * - disabled — if true (or href missing), renders a <span> with aria-disabled so it is not a fake link.
+   * - href — app path (default: /groups/new); passed through resolve() when the control is a link.
+   * - disabled — with no href, shows an inactive control (not a fake link).
    *
-   * Styling: global classes in styleguide.css — .button .button-primary .button-large .button-spread,
-   * plus .button-text / .button-icon for layout. Same pattern as Button.svelte + docs in styleguide.
+   * Renders `<span aria-disabled>` when there is no real link, otherwise `<a href={resolve(href)}>`.
+   * Label + icon are written once using `<svelte:element>` (DRY).
    */
   let { label = "Create New Group", disabled = false, href = "/groups/new" } = $props();
+
+  let inactive = $derived(disabled || !href);
+  let rootTag = $derived(inactive ? "span" : "a");
+  let rootAttrs = $derived(
+    inactive ? { "aria-disabled": "true" } : { href: resolve(href) }
+  );
 </script>
 
-<!-- If disabled (or no action), show non-clickable version -->
-{#if disabled || !href}
-  <span
-    class="button button-primary button-large button-spread"
-    aria-disabled="true"
-  >
-    <span class="button-text">{label}</span>
-    <span class="button-icon">
-      <PulsIconNoBackground width={24} height={24} />
-    </span>
+<svelte:element this={rootTag} class="add-group-btn" {...rootAttrs}>
+  <span class="add-group-btn__text">{label}</span>
+  <span class="add-group-btn__icon">
+    <PulsIconNoBackground width={22} height={22} />
   </span>
-{:else}
-  <!-- Real link: works with JS off;  -->
-  <a class="button button-primary button-large button-spread" {href}>
-    <span class="button-text">{label}</span>
-    <span class="button-icon">
-      <PulsIconNoBackground width={24} height={24} />
-    </span>
-  </a>
-{/if}
+</svelte:element>
+

--- a/src/lib/components/groups/AddGroupButton.svelte
+++ b/src/lib/components/groups/AddGroupButton.svelte
@@ -1,4 +1,6 @@
 <script>
+  import PulsIconNoBackground from "$lib/assets/svg/puls-icon-no-background.svelte";
+
   /**
    * Simple props:
    * - label: text inside the button
@@ -12,14 +14,18 @@
 {#if disabled || !href}
   <span class="add-group-btn" aria-disabled="true">
     <span class="add-group-btn__text">{label}</span>
-    <span class="add-group-btn__icon" aria-hidden="true">+</span>
+    <span class="add-group-btn__icon">
+      <PulsIconNoBackground width={22} height={22} />
+    </span>
   </span>
 {:else}
   <!-- Link-first for progressive enhancement -->
   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
   <a class="add-group-btn" {href}>
     <span class="add-group-btn__text">{label}</span>
-    <span class="add-group-btn__icon" aria-hidden="true">+</span>
+    <span class="add-group-btn__icon">
+      <PulsIconNoBackground width={22} height={22} />
+    </span>
   </a>
 {/if}
 
@@ -30,7 +36,7 @@
     align-items: center;
     justify-content: space-between;
     gap: var(--spacing-lg);
-    min-width: min(100%, 20rem);
+    min-width: min(90%, 10rem);
     margin: 0;
     appearance: none;
     padding: var(--spacing-sm) var(--spacing-lg);
@@ -80,9 +86,7 @@
       align-items: center;
       justify-content: center;
       flex-shrink: 0;
-      font-size: clamp(24px, 5vw, 32px);
-      line-height: 1;
-      font-weight: 400;
+      color: inherit;
     }
   }
 

--- a/src/lib/components/groups/AddGroupButton.svelte
+++ b/src/lib/components/groups/AddGroupButton.svelte
@@ -2,101 +2,36 @@
   import PulsIconNoBackground from "$lib/assets/svg/puls-icon-no-background.svelte";
 
   /**
-   * Simple props:
-   * - label: text inside the button
-   * - href: go to another page
-   * - disabled: show disabled button style
+   * “Create new group” control for the groups page.
+   *
+   * Props:
+   * - label — visible text (default: “Create New Group”).
+   * - href  — where the link goes (default: /groups/new). Works without JS (real <a>).
+   * - disabled — if true (or href missing), renders a <span> with aria-disabled so it is not a fake link.
+   *
+   * Styling: global classes in styleguide.css — .button .button-primary .button-large .button-spread,
+   * plus .button-text / .button-icon for layout. Same pattern as Button.svelte + docs in styleguide.
    */
   let { label = "Create New Group", disabled = false, href = "/groups/new" } = $props();
 </script>
 
 <!-- If disabled (or no action), show non-clickable version -->
 {#if disabled || !href}
-  <span class="add-group-btn" aria-disabled="true">
-    <span class="add-group-btn__text">{label}</span>
-    <span class="add-group-btn__icon">
-      <PulsIconNoBackground width={22} height={22} />
+  <span
+    class="button button-primary button-large button-spread"
+    aria-disabled="true"
+  >
+    <span class="button-text">{label}</span>
+    <span class="button-icon">
+      <PulsIconNoBackground width={24} height={24} />
     </span>
   </span>
 {:else}
-  <!-- Link-first for progressive enhancement -->
-  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-  <a class="add-group-btn" {href}>
-    <span class="add-group-btn__text">{label}</span>
-    <span class="add-group-btn__icon">
-      <PulsIconNoBackground width={22} height={22} />
+  <!-- Real link: works with JS off;  -->
+  <a class="button button-primary button-large button-spread" {href}>
+    <span class="button-text">{label}</span>
+    <span class="button-icon">
+      <PulsIconNoBackground width={24} height={24} />
     </span>
   </a>
 {/if}
-
-<style>
-  /* Same look for span, button, and link versions */
-  .add-group-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-lg);
-    min-width: min(90%, 10rem);
-    margin: 0;
-    appearance: none;
-    padding: var(--spacing-sm) var(--spacing-lg);
-    border: none;
-    border-radius: var(--radius-md);
-    background: var(--blue-500);
-    color: var(--background-color-primary);
-    font-family: var(--main-font);
-    font-size: clamp(14px, 2vw, 16px);
-    font-weight: 500;
-    line-height: 1.2;
-    white-space: nowrap;
-    cursor: pointer;
-    text-decoration: none;
-    transition:
-      background var(--transition-fast),
-      transform var(--transition-fast),
-      box-shadow var(--transition-fast);
-
-    &:hover:not([aria-disabled="true"]) {
-      background: var(--blue-600);
-      transform: translateY(-1px);
-      box-shadow: var(--shadow-md);
-    }
-
-    &:focus-visible {
-      outline: 2px solid var(--grey-50, #fff);
-      outline-offset: 2px;
-    }
-
-    &[aria-disabled="true"],
-    &:disabled {
-      opacity: 0.55;
-      cursor: not-allowed;
-      box-shadow: none;
-      transform: none;
-    }
-
-    .add-group-btn__text {
-      /* Keep long text from breaking layout */
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .add-group-btn__icon {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      flex-shrink: 0;
-      color: inherit;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .add-group-btn {
-      transition: none;
-
-      &:hover:not([aria-disabled="true"]) {
-        transform: none;
-      }
-    }
-  }
-</style>

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -1,7 +1,8 @@
 <script>
   import GroupAboutBanner from "$lib/components/groups/GroupAboutBanner.svelte";
   import GroupCard from "$lib/components/groups/GroupCard.svelte";
-  import GroupFilter from "$lib/components/groupFilter/GroupFilter.svelte"
+  import GroupFilter from "$lib/components/groupFilter/GroupFilter.svelte";
+  import AddGroupButton from "$lib/components/groups/AddGroupButton.svelte";
 
   // `data` is injected by SvelteKit from +page.server.js
   // It contains the groups array fetched from Directus
@@ -27,7 +28,10 @@
     <GroupAboutBanner>
       Manage members, invite users by email, and quickly update group access.
     </GroupAboutBanner>
-    <GroupFilter />
+    <div class="groups-controls">
+      <GroupFilter />
+      <AddGroupButton href="/groups/new" />
+    </div>
   {#if isLoading}
   <!-- Loading state -->
   <p>Loading groups...</p>
@@ -79,7 +83,15 @@
       gap: var(--spacing-lg);
       align-items: start;
     }
-   .groups-status {
+
+    .groups-controls {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: var(--spacing-sm);
+    }
+
+    .groups-status {
       color: var(--grey-500);
       text-align: center;
       padding: var(--spacing-xl) 0;


### PR DESCRIPTION
## What does this change?

Resolves issue #367

Adds an "Create New Group" button to the groups page so admins can create the new group card. 



## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images

<img width="989" height="638" alt="Screenshot 2026-05-11 at 13 28 57" src="https://github.com/user-attachments/assets/43d2c95f-44fb-4751-9f94-c366d1cc9514" />



## How to review

1. Pull the branch and open the groups page
2. The "Create New Group" button should appear next to the filter
3. Click it — should navigate to `/groups/new`
4. Tab to the button and confirm focus-visible outline appears




