### PR TITLE
362 userstory update group card layout

### DIFF
--- a/src/lib/components/groups/GroupCard.svelte
+++ b/src/lib/components/groups/GroupCard.svelte
@@ -1,10 +1,11 @@
+<!-- GroupCard.svelte -->
+<!-- Front face shows assigned articles + invite form. Back face shows full member list. -->
 <script>
   import DetailsUpIcon from "$lib/assets/svg/DetailsUpIcon.svelte";
   import GroupCardHeader from "$lib/components/groups/GroupCardHeader.svelte";
   import GroupInviteForm from "$lib/components/groups/GroupInviteForm.svelte";
   import GroupMemberCard from "$lib/components/groups/GroupMemberCard.svelte";
   import SwitchSidesButton from "$lib/components/groups/SwitchSidesButton.svelte";
-  import UserSectionDropdown from "$lib/components/groups/UserSectionDropdown.svelte";
   import previewAvatarFallback from "$lib/assets/img/profile-avatar.webp";
 
   // Group data is passed from the groups page; `form` is invite action feedback from +page.svelte
@@ -20,25 +21,25 @@
     flipped = false;
   }
 
-  // Max number of member avatars to show in the preview
-  const MAX_PREVIEW_MEMBERS = 2;
-
   // Fallback values keep the component safe while API data is still incomplete
   const groupId = $derived(group?.id ?? "");
   const groupName = $derived(group?.name ?? "Unnamed group");
   const groupStatus = $derived(group?.status ?? "Unknown");
   const conditionLabel = $derived(group?.conditionlabel ?? "General");
-
-  // Members array from group data — now populated from footguard_group_members
-  const members = $derived(Array.isArray(group?.members) ? group.members : []);
-  const memberCount = $derived(group?.memberCount ?? members.length);
+  const groupImage = $derived(group?.image ?? null);
 
   const faceIdSuffix = $derived(String(group?.id ?? "unknown"));
   const frontFaceId = $derived(`group-${faceIdSuffix}`);
   const membersFaceId = $derived(`group-${faceIdSuffix}-members`);
-  const groupImage = $derived(group?.image ?? null);
 
-  // make clear order for roles in back face list
+  // Members array from group data — populated from footguard_group_members
+  const members = $derived(Array.isArray(group?.members) ? group.members : []);
+  const memberCount = $derived(group?.memberCount ?? members.length);
+
+  // Articles array from group data — populated from footguard_articles
+  const articles = $derived(Array.isArray(group?.articles) ? group.articles : []);
+
+  // Sort order for roles on the back face
   // first super admin, then admin, then assessor, then viewer
   const rolePriority = {
     'super admin': 0,
@@ -48,7 +49,7 @@
     vister: 3
   };
 
-  // if role not known keep it in the end
+  // Returns sort priority for a given role — unknown roles go to the end
   function getRolePriority(role) {
     const normalizedRole = String(role ?? "").trim().toLowerCase();
     return rolePriority[normalizedRole] ?? 99;
@@ -56,7 +57,7 @@
 
   const membersForBackFace = $derived(
     [...members]
-      // sort members by role order we need in design
+      // Sort members by role priority for consistent display order
       .sort((a, b) => getRolePriority(a?.role) - getRolePriority(b?.role))
       .map((m) => ({
         id: m.id,
@@ -65,16 +66,13 @@
         avatarUrl: m.avatarUrl ?? previewAvatarFallback
       }))
   );
-
-  const isPlural = $derived(memberCount !== 1);
-
-  const previewMembers = $derived(members.slice(0, MAX_PREVIEW_MEMBERS));
 </script>
 
 <article class="group-card-root">
   <div class="scene">
     <div class="flipper" class:flipped={flipped}>
-      <!-- Front: summary + invite + details -->
+
+      <!-- Front face: group header + articles list + invite form + articles dropdown -->
       <div class="face face--front" id={frontFaceId}>
         <div class="group-card-header">
           <GroupCardHeader
@@ -83,62 +81,57 @@
             conditionLabel={conditionLabel}
             image={groupImage}
           />
+          <!-- Button to flip card to the members back face -->
           <SwitchSidesButton label="Members" onclick={flipToMembers} />
         </div>
 
         <section class="members-section">
-          <h2 class="title">Assessors</h2>
+          <h2 class="title">Articles</h2>
 
-          <!-- Member avatar preview row with add button -->
-          <div class="members-preview">
-            {#if previewMembers.length > 0}
-              <ul aria-label="Current members preview">
-                {#each previewMembers as member (member.id)}
-                  <li>
-                    <img
-                      class="members-preview-av"
-                      src={member.avatarUrl ?? previewAvatarFallback}
-                      alt={member.name ?? `Group member ${member.id}`}
-                    />
-                  </li>
-                {/each}
-              </ul>
-            {/if}
-
-            <!-- Dashed circle add button next to avatars -->
-            <button class="btn-add" type="button" aria-label="Add team member">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
-              </svg>
-            </button>
-          </div>
-
-          {#if previewMembers.length === 0}
-            <p class="members-empty">No members available yet.</p>
+          {#if articles.length > 0}
+            <!-- Article list: shows title of each article assigned to this group -->
+            <ul class="articles-list">
+              {#each articles as article (article.id)}
+                <li class="article-item">
+                  <span class="article-title">{article.title}</span>
+                </li>
+              {/each}
+            </ul>
+          {:else}
+            <!-- Empty state: shown when no articles are assigned to this group -->
+            <p class="members-empty">No articles assigned yet.</p>
           {/if}
 
+          <!-- Invite form: label changed from assessor to member per new design -->
           <GroupInviteForm {groupId} {members} {form} />
         </section>
 
+        <!-- Dropdown: shows article count and list of article titles -->
         <details>
           <summary>
-            <span>{memberCount} Assessor{isPlural ? "s" : ""}</span>
+            <span>{articles.length} Article{articles.length !== 1 ? "s" : ""}</span>
             <span class="chevron">
               <DetailsUpIcon />
             </span>
           </summary>
           <div class="members-dropdown-panel">
-            <UserSectionDropdown {members} />
+            <!-- Show assigned articles in dropdown instead of assessors -->
+            {#if articles.length > 0}
+              <ul class="articles-list">
+                {#each articles as article (article.id)}
+                  <li class="article-item">
+                    <span class="article-title">{article.title}</span>
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="articles-empty">No articles assigned yet.</p>
+            {/if}
           </div>
         </details>
       </div>
 
-      <!-- Back: full member list -->
+      <!-- Back face: full member list — unchanged -->
       <div class="face face--back" id={membersFaceId}>
         <GroupMemberCard
           {groupId}
@@ -149,6 +142,7 @@
           onBack={flipToFront}
         />
       </div>
+
     </div>
   </div>
 </article>
@@ -220,55 +214,6 @@
     }
   }
 
-  .members-preview {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-xs);
-    margin-bottom: var(--spacing-lg);
-
-    ul {
-      display: flex;
-      align-items: center;
-      gap: var(--spacing-xs);
-      margin: 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .btn-add {
-      width: 3rem;
-      height: 3rem;
-      border-radius: var(--radius-full);
-      border: 2px dashed var(--grey-300);
-      background: transparent;
-      color: var(--grey-400);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      cursor: pointer;
-      transition:
-        border-color var(--transition-fast),
-        color var(--transition-fast);
-      flex-shrink: 0;
-
-      svg {
-        width: 1.25rem;
-        height: 1.25rem;
-      }
-    }
-  }
-
-  .members-preview-av {
-    width: 3rem;
-    height: 3rem;
-    border-radius: var(--radius-full);
-    border: 2px solid var(--background-color-primary);
-    object-fit: cover;
-    object-position: center;
-    background: var(--grey-100);
-    box-shadow: var(--shadow-sm);
-  }
-
   .title {
     margin: 0 0 var(--spacing-sm);
     font-size: 1rem;
@@ -276,10 +221,48 @@
     color: var(--grey-700);
   }
 
+  /* Empty state for members section */
   .members-empty {
     margin: 0 0 var(--spacing-lg);
     font-size: 0.875rem;
     color: var(--grey-500);
+  }
+
+  /* Article list shown in main section and in dropdown */
+  .articles-list {
+    margin: 0 0 var(--spacing-lg);
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0;
+  }
+
+  .article-item {
+    padding: var(--spacing-sm) 0;
+    border-bottom: 1px solid var(--grey-100);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  /* Truncate long article titles to max 2 lines */
+  .article-title {
+    color: var(--grey-700);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  /* Empty state inside the dropdown panel */
+  .articles-empty {
+    padding: var(--spacing-md) var(--spacing-lg);
+    margin: 0;
+    color: var(--grey-500);
+    font-size: var(--font-size-sm);
   }
 
   details {

--- a/src/lib/components/groups/GroupInviteForm.svelte
+++ b/src/lib/components/groups/GroupInviteForm.svelte
@@ -74,7 +74,7 @@
   </script>
 
 
-<label for="add-member-email">Add assessor by email</label>
+<label for="add-member-email">Add member by email</label>
 
 <!-- Form uses addMember action — no email is sent, user is directly added -->
 <form method="POST" action="?/addMember" use:enhance={handleSubmit}>

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -326,3 +326,46 @@ export async function removeMemberFromGroup(memberId, updatedByUserId = null) {
   const json = await response.json()
   return json.data
 }
+
+/**
+ * Fetches all articles assigned to a specific workgroup from footguard_articles.
+ * Uses the assigned_workgroup field to filter by group ID.
+ *
+ * @param {string|number} groupId - The ID of the workgroup
+ * @returns {Promise<Array>} List of article objects with title, publisher and theme
+ * @throws {Error} If the API call fails
+ */
+export async function getGroupArticles(groupId) {
+  // Filter articles where assigned_workgroup matches the group ID
+  const url = `${DIRECTUS_URL}/items/footguard_articles?filter[assigned_workgroup][_eq]=${groupId}&fields=id,title,publisher,publishing_year,theme,status&limit=-1`
+
+  let response
+  try {
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${DIRECTUS_TOKEN}`,
+        'Content-Type': 'application/json'
+      }
+    })
+  } catch (networkError) {
+    throw new Error(`Network error while fetching group articles: ${networkError.message}`)
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Directus API error while fetching group articles: ${response.status} ${response.statusText}`
+    )
+  }
+
+  const json = await response.json()
+
+  // Map to a clean UI-friendly format
+  return (json.data ?? []).map((article) => ({
+    id: article.id,
+    title: article.title ?? 'Untitled',
+    publisher: article.publisher ?? null,
+    publishingYear: article.publishing_year ?? null,
+    theme: article.theme ?? null,
+    status: article.status ?? null
+  }))
+}

--- a/src/routes/groups/+page.server.js
+++ b/src/routes/groups/+page.server.js
@@ -6,7 +6,6 @@ import {
   fetchGroups,
   findUserByEmail,
   addUserToGroup,
-  getGroupMembers,
   removeMemberFromGroup,
   getGroupArticles
 } from '$lib/server/groups.js'
@@ -17,24 +16,19 @@ export async function load() {
   try {
     const groups = await fetchGroups()
 
-    // Fetch members AND articles for each group in parallel
+    // Fetch only articles per group — members are already included in fetchGroups()
     const groupsWithData = await Promise.all(
       groups.map(async (group) => {
         try {
-          // Fetch members and articles at the same time for performance
-          const [members, articles] = await Promise.all([
-            getGroupMembers(group.id),
-            getGroupArticles(group.id) // ← nieuw
-          ])
+          // Members already fetched inside fetchGroups(), only articles need separate fetch
+          const articles = await getGroupArticles(group.id)
           return {
             ...group,
-            members,
-            memberCount: members.length,
-            articles // ← nieuw
+            articles
           }
         } catch {
-          // If data fails for one group, keep page functional for others
-          return { ...group, members: [], memberCount: 0, articles: [] }
+          // If articles fail for one group, keep page functional for others
+          return { ...group, articles: [] }
         }
       })
     )

--- a/src/routes/groups/+page.server.js
+++ b/src/routes/groups/+page.server.js
@@ -7,7 +7,8 @@ import {
   findUserByEmail,
   addUserToGroup,
   getGroupMembers,
-  removeMemberFromGroup
+  removeMemberFromGroup,
+  getGroupArticles
 } from '$lib/server/groups.js'
 import { error, fail } from '@sveltejs/kit'
 
@@ -16,22 +17,31 @@ export async function load() {
   try {
     const groups = await fetchGroups()
 
-    // Fetch members for each group in parallel.
-    const groupsWithMembers = await Promise.all(
+    // Fetch members AND articles for each group in parallel
+    const groupsWithData = await Promise.all(
       groups.map(async (group) => {
         try {
-          const members = await getGroupMembers(group.id)
-          return { ...group, members, memberCount: members.length }
+          // Fetch members and articles at the same time for performance
+          const [members, articles] = await Promise.all([
+            getGroupMembers(group.id),
+            getGroupArticles(group.id) // ← nieuw
+          ])
+          return {
+            ...group,
+            members,
+            memberCount: members.length,
+            articles // ← nieuw
+          }
         } catch {
-          // If members fail for one group, keep page functional for others.
-          return { ...group, members: [], memberCount: 0 }
+          // If data fails for one group, keep page functional for others
+          return { ...group, members: [], memberCount: 0, articles: [] }
         }
       })
     )
 
     // Pass groups (with their members) to +page.svelte via the data prop
     return {
-      groups: groupsWithMembers,
+      groups: groupsWithData,
       loadError: null
     }
   } catch {


### PR DESCRIPTION
## What does this change?

Resolves issue #362 

Previously the front face of a group card showed assessors (avatar 
preview, invite form, and a dropdown with member list). This was 
confusing because users wanted to quickly understand the group content 
before viewing its members.

The front face now shows the assigned articles for that group instead.
Members are still accessible via the back face by clicking "Members".

changes:
- Front face now shows a list of assigned article titles
- Dropdown now shows article count and article titles instead of assessors
- Avatar preview row and + button removed from front face
- Back face with full member list remains completely unchanged


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images


<img width="417" height="684" alt="Screenshot 2026-05-12 at 12 33 19" src="https://github.com/user-attachments/assets/d0737e2c-b28f-427e-81c0-7e50a105a371" />
<img width="401" height="533" alt="Screenshot 2026-05-12 at 12 33 04" src="https://github.com/user-attachments/assets/4a99a93b-abe3-4895-9012-d190a74cd231" />


## How to review

1. Go to the `/groups` page
2. Check that the front of each group card shows "Articles" section
3. Verify articles titles are listed — empty state shows when none assigned
4. Click the dropdown to see article count and titles
5. Click "Members" button to flip to back face
6. Verify back face still shows full member list with roles
7. Click "Back" to return to front face
