### PR TITLE
feat(groups): add createGroup backend action and reactive list update…

### DIFF
--- a/src/lib/components/form/FilterForm.svelte
+++ b/src/lib/components/form/FilterForm.svelte
@@ -18,7 +18,7 @@
 
 <form method="get" class="filter-form-container">
 	<label for="status" class="visually-hidden">filter status</label>
-	<select id="status" name="status" class="filter-button" bind:value={status} on:change={handleChange}>
+	<select id="status" name="status" class="filter-button" bind:value={status} onchange={handleChange}>
 		<option value="all">Status</option>
 		<option value="Not started">Not started</option>
 		<option value="Finished">Finished</option>
@@ -26,7 +26,7 @@
 	</select>
 
 	<label for="theme" class="visually-hidden">filter theme</label>
-	<select id="theme" name="theme" class="filter-button" bind:value={theme} on:change={handleChange}>
+	<select id="theme" name="theme" class="filter-button" bind:value={theme} onchange={handleChange}>
 		<option value="all">Themes</option>
 		<option value="Temperature">Temperature</option>
 		<option value="Ulcers">Ulcers</option>

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -369,3 +369,62 @@ export async function getGroupArticles(groupId) {
     status: article.status ?? null
   }))
 }
+
+/**
+ * Creates a new workgroup in Directus.
+ * Only group_name is required; all other fields are optional.
+ *
+ * @param {object} groupData - The group fields to create
+ * @param {string} groupData.groupName - Required: the name of the group
+ * @param {string|null} groupData.conditionLabel - Optional: label for the condition
+ * @param {string|null} groupData.status - Optional: e.g. 'active', 'draft'
+ * @param {number|null} groupData.createdByUserId - Optional: ID of the creating user
+ * @param {string|null} groupData.imageId - Optional: Directus file ID for thumbnail
+ * @returns {Promise<object>} The created workgroup record
+ * @throws {Error} If the API call fails
+ */
+export async function createGroup({
+  groupName,
+  conditionLabel = null,
+  status = null,
+  createdByUserId = null,
+  imageId = null
+}) {
+  if (!groupName?.trim()) {
+    throw new Error('Group name is required.')
+  }
+
+  const url = `${DIRECTUS_URL}/items/footguard_workgroups`
+
+  // Only include fields that have a value — Directus handles nulls fine,
+  // but this keeps the payload clean and explicit.
+  const body = {
+    group_name: groupName.trim(),
+    ...(conditionLabel ? { condition_label: conditionLabel.trim() } : {}),
+    ...(status ? { status } : {}),
+    ...(createdByUserId ? { created_by_user_id: Number(createdByUserId) } : {}),
+    ...(imageId ? { image: imageId } : {})
+  }
+
+  let response
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DIRECTUS_TOKEN}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    })
+  } catch (networkError) {
+    throw new Error(`Network error while creating group: ${networkError.message}`)
+  }
+
+  if (!response.ok) {
+    const errorBody = await response.text()
+    throw new Error(`Directus API error while creating group: ${response.status} - ${errorBody}`)
+  }
+
+  const json = await response.json()
+  return json.data
+}

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -4,46 +4,100 @@ import { redirect } from '@sveltejs/kit'
 const BASE_URL = 'https://fdnd-agency.directus.app'
 
 export async function load({ fetch, locals }) {
-  // Niet ingelogd -> naar login pagina
   if (!locals.user) {
     throw redirect(302, '/login')
   }
 
-  const currentUserId = locals.user.id
+  const headers = {}
+
+  const token =
+    locals.accessToken ||
+    locals.token ||
+    locals.session?.access_token ||
+    locals.session?.accessToken
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
   try {
-    const usersRes = await fetch(
-      `${BASE_URL}/items/footguard_users?filter[id][_eq]=${encodeURIComponent(currentUserId)}&limit=1`
-    )
-    const usersData = await usersRes.json()
+    const userId = locals.user.id
+    const email = locals.user.email
 
-    const users = usersData.data || []
+    let currentUser = null
 
-    const currentUser = users[0] || { name: 'Guest', id: null }
+    if (email) {
+      const userByEmailRes = await fetch(
+        `${BASE_URL}/items/footguard_users?filter[email][_eq]=${encodeURIComponent(email)}&limit=1`,
+        { headers }
+      )
 
-    if (!currentUser.id) {
-      return {
-        articles: [],
-        currentUser,
-        allUsers: users
+      const userByEmailData = await userByEmailRes.json()
+
+      currentUser = userByEmailData.data?.[0] ?? null
+    }
+
+    if (!currentUser && userId) {
+      const userByIdRes = await fetch(
+        `${BASE_URL}/items/footguard_users?filter[id][_eq]=${encodeURIComponent(userId)}&limit=1`,
+        { headers }
+      )
+
+      const userByIdData = await userByIdRes.json()
+
+      currentUser = userByIdData.data?.[0] ?? null
+    }
+
+    if (!currentUser) {
+      currentUser = {
+        id: userId,
+        name: formatNameFromEmail(email),
+        email,
+        role: locals.user.role ?? '',
+        profession: ''
       }
     }
 
-    const articlesRes = await fetch(
-      `${BASE_URL}/items/footguard_articles?fields=*,assigned_to.*,assessor_2.*&filter[assigned_to][_eq]=${currentUser.id}`
-    )
-    const articlesData = await articlesRes.json()
-    const articles = articlesData.data || []
+    let articles = []
+
+    if (currentUser.id) {
+      const articlesRes = await fetch(
+        `${BASE_URL}/items/footguard_articles?fields=*,assigned_to.*,assessor_2.*&filter[assigned_to][_eq]=${encodeURIComponent(currentUser.id)}`,
+        { headers }
+      )
+
+      const articlesData = await articlesRes.json()
+
+      articles = articlesData.data ?? []
+    }
 
     return {
       articles,
       currentUser,
-      allUsers: users
+      allUsers: currentUser.id ? [currentUser] : []
     }
-  } catch {
+  } catch (error) {
+    console.error('Dashboard load error:', error)
+
     return {
       articles: [],
-      currentUser: { name: 'Guest', id: null },
+      currentUser: {
+        id: locals.user.id,
+        name: formatNameFromEmail(locals.user.email),
+        email: locals.user.email ?? '',
+        role: locals.user.role ?? '',
+        profession: ''
+      },
       allUsers: []
     }
   }
+}
+
+function formatNameFromEmail(email) {
+  if (!email) return 'Guest'
+
+  const firstPart = email.split('@')[0]
+  const firstName = firstPart.split('.')[0]
+
+  return firstName.charAt(0).toUpperCase() + firstName.slice(1)
 }

--- a/src/routes/groups/+page.server.js
+++ b/src/routes/groups/+page.server.js
@@ -7,7 +7,8 @@ import {
   findUserByEmail,
   addUserToGroup,
   removeMemberFromGroup,
-  getGroupArticles
+  getGroupArticles,
+  createGroup
 } from '$lib/server/groups.js'
 import { error, fail } from '@sveltejs/kit'
 
@@ -146,6 +147,64 @@ export const actions = {
     } catch (err) {
       return fail(500, {
         error: err.message || 'Failed to remove member. Please try again.'
+      })
+    }
+  },
+  /**
+   * Handles creating a new workgroup.
+   * Only group_name is required; condition_label, status, and image are optional.
+   * Image upload (multipart/file) is handled separately — for now only text fields.
+   *
+   * @type {import('./$types').Actions}
+   */
+  createGroup: async ({ request, locals }) => {
+    const data = await request.formData()
+    const currentUserId = locals.user?.id ?? null
+
+    const groupName = data.get('groupName')?.toString().trim()
+    const conditionLabel = data.get('conditionLabel')?.toString().trim() || null
+    const status = data.get('status')?.toString().trim() || null
+    // imageId comes later when the frontend modal with file upload is built
+    const imageId = data.get('imageId')?.toString().trim() || null
+
+    // --- Validation: group name is the only required field ---
+    if (!groupName) {
+      return fail(400, {
+        error: 'Group name is required.',
+        field: 'groupName',
+        action: 'createGroup'
+      })
+    }
+
+    try {
+      const newGroup = await createGroup({
+        groupName,
+        conditionLabel,
+        status,
+        createdByUserId: currentUserId,
+        imageId
+      })
+
+      // Return the new group so the frontend can append it to the list
+      // without a full page reload.
+      return {
+        success: true,
+        action: 'createGroup',
+        group: {
+          id: newGroup.id,
+          name: newGroup.group_name,
+          status: newGroup.status ?? null,
+          conditionlabel: newGroup.condition_label ?? 'General',
+          members: [],
+          memberCount: 0,
+          articles: [],
+          image: null // image upload handled later
+        }
+      }
+    } catch (err) {
+      return fail(500, {
+        error: err.message || 'Failed to create group. Please try again.',
+        action: 'createGroup'
       })
     }
   }

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -8,15 +8,35 @@
   // It contains the groups array fetched from Directus
   export let data;
   export let form;
-
-  // Extract groups safely (fallback to empty array)
-  // Reactive statement: automatically updates `groups` whenever `data.groups` changes.
-  // Uses a fallback empty array to prevent errors when no data is available yet.
-  $: groups = data.groups ?? [];
+ 
+  // Holds groups created during this session (not yet in server data).
+  // Kept separate so server data changes don't wipe newly added groups.
+  let extraGroups = [];
+ 
+  // Merge server groups + locally added groups, deduplicate by id.
+  // Deduplication prevents doubles if the server data refreshes and already
+  // includes a group that was added via the createGroup action.
+  $: groups = [...(data.groups ?? []), ...extraGroups].filter(
+    (g, i, arr) => arr.findIndex((x) => x.id === g.id) === i
+  );
+ 
   $: loadError = data.loadError ?? null;
-
+ 
   // Loading state is true until groups or an error value is available
   $: isLoading = !data?.groups && !data?.loadError;
+ 
+  // When createGroup succeeds, append the new group to extraGroups so it
+  // appears in the list immediately without a full page reload.
+  $: if (form?.action === 'createGroup' && form?.success && form?.group) {
+    const alreadyExists =
+      (data.groups ?? []).some((g) => g.id === form.group.id) ||
+      extraGroups.some((g) => g.id === form.group.id);
+ 
+    if (!alreadyExists) {
+      extraGroups = [form.group, ...extraGroups];
+    }
+  }
+
 </script>
 
 <section class="groups-page">

--- a/src/routes/profile/+page.server.js
+++ b/src/routes/profile/+page.server.js
@@ -12,50 +12,103 @@ function formFieldsFromUser(sourceUser = {}) {
   }
 }
 
+function formatNameFromEmail(email) {
+  if (!email) return 'Unknown user'
+
+  const firstPart = email.split('@')[0]
+  const firstName = firstPart.split('.')[0]
+
+  return firstName.charAt(0).toUpperCase() + firstName.slice(1)
+}
+
+function normalizeSessionUser(sessionUser = {}) {
+  return {
+    id: sessionUser.id,
+    name: sessionUser.name ?? formatNameFromEmail(sessionUser.email),
+    role: sessionUser.role ?? '',
+    institute: sessionUser.institute ?? '',
+    profession: sessionUser.profession ?? '',
+    email: sessionUser.email ?? ''
+  }
+}
+
 // This is my Directus base url.
 const DIRECTUS_URL = env.PUBLIC_DIRECTUS_URL || 'https://fdnd-agency.directus.app'
+
 // This token i use on server to update Directus data.
 const DIRECTUS_TOKEN = privateEnv.DIRECTUS_TOKEN
+
+function directusHeaders() {
+  const headers = {}
+
+  if (DIRECTUS_TOKEN) {
+    headers.Authorization = `Bearer ${DIRECTUS_TOKEN}`
+  }
+
+  return headers
+}
 
 // This load run when profile page open.
 // Here i get current user data from Directus by email,
 // so page show real latest profile info.
 export async function load({ fetch, locals, url }) {
   const sessionUser = locals.user
+
+  if (!sessionUser) {
+    throw redirect(302, '/login')
+  }
+
   const isEditMode = url.searchParams.has('edit')
   const saved = url.searchParams.get('saved') === '1'
   const saveWarning = url.searchParams.get('warning') ?? ''
 
-  // Get user by exact email from session.
-  const usersResponse = await fetch(
-    `${DIRECTUS_URL}/items/footguard_users?` +
-      `filter[email][_eq]=${encodeURIComponent(sessionUser.email)}&limit=1`
-  )
+  const fallbackUser = normalizeSessionUser(sessionUser)
 
-  // If request fail, i fallback to session user.
-  if (!usersResponse.ok) {
-    const user = sessionUser
+  try {
+    // Get user by exact email from session.
+    const usersResponse = await fetch(
+      `${DIRECTUS_URL}/items/footguard_users?` +
+        `filter[email][_eq]=${encodeURIComponent(sessionUser.email)}&limit=1`,
+      {
+        headers: directusHeaders()
+      }
+    )
+
+    // If request fail, i fallback to session user.
+    if (!usersResponse.ok) {
+      return {
+        user: fallbackUser,
+        isEditMode,
+        saved,
+        saveWarning,
+        ...(isEditMode ? { editForm: formFieldsFromUser(fallbackUser) } : {})
+      }
+    }
+
+    // Directus return user list in data array.
+    const usersResult = await usersResponse.json()
+    const [user] = usersResult?.data ?? []
+
+    const resolvedUser = user ?? fallbackUser
+
+    // If user found use it, else use session user.
     return {
-      user,
+      user: resolvedUser,
       isEditMode,
       saved,
       saveWarning,
-      ...(isEditMode ? { editForm: formFieldsFromUser(user) } : {})
+      ...(isEditMode ? { editForm: formFieldsFromUser(resolvedUser) } : {})
     }
-  }
+  } catch (error) {
+    console.error('Profile load error:', error)
 
-  // Directus return user list in data array.
-  const usersResult = await usersResponse.json()
-  const [user] = usersResult?.data ?? []
-  const resolvedUser = user ?? sessionUser
-
-  // If user found use it, else use session user.
-  return {
-    user: resolvedUser,
-    isEditMode,
-    saved,
-    saveWarning,
-    ...(isEditMode ? { editForm: formFieldsFromUser(resolvedUser) } : {})
+    return {
+      user: fallbackUser,
+      isEditMode,
+      saved,
+      saveWarning,
+      ...(isEditMode ? { editForm: formFieldsFromUser(fallbackUser) } : {})
+    }
   }
 }
 
@@ -75,90 +128,137 @@ export const actions = {
   // Called from: /profile?/saveProfile
   saveProfile: async ({ request, fetch, locals }) => {
     const sessionUser = locals.user
+
     // Must be logged in.
     if (!sessionUser) return fail(401, { message: 'Unauthorized' })
+
     // Token must exist on server.
     if (!DIRECTUS_TOKEN) return fail(500, { message: 'Server config missing' })
 
     // Read JSON body from frontend.
     const form = await request.formData().catch(() => null)
+
     if (!form) return fail(400, { message: 'Invalid request body' })
 
     // I use session user id for secure update.
     const userId = sessionUser.id
-    if (!userId) return fail(400, { message: 'Could not resolve user id for update' })
+
+    if (!userId) {
+      return fail(400, { message: 'Could not resolve user id for update' })
+    }
 
     // Fields that can be edited in profile form.
-    const name = String(form.get('name') ?? '')
-    const institute = String(form.get('institute') ?? '')
-    const profession = String(form.get('profession') ?? '')
-    const email = String(form.get('email') ?? '')
+    const name = String(form.get('name') ?? '').trim()
+    const institute = String(form.get('institute') ?? '').trim()
+    const profession = String(form.get('profession') ?? '').trim()
+    const email = String(form.get('email') ?? '').trim()
+
     // Main fields save first.
     const corePayload = {
-      name: String(name).trim(),
-      institute: String(institute).trim(),
-      profession: String(profession).trim()
+      name,
+      institute,
+      profession
     }
 
     const photoRaw = form.get('photo')
+
     if (typeof photoRaw === 'string' && photoRaw.trim()) {
       corePayload.photo = photoRaw.trim()
     }
 
     // Update the input fields in Directus.
-    const updateResponse = await patchUser({ fetch, userId, payload: corePayload })
+    const updateResponse = await patchUser({
+      fetch,
+      userId,
+      payload: corePayload
+    })
+
     if (!updateResponse.ok) {
       const details = await updateResponse.text().catch(() => '')
-      return fail(400, { message: 'Failed to save core profile fields', details })
+
+      return fail(400, {
+        message: 'Failed to save core profile fields',
+        details
+      })
     }
 
     // Optional warnings list (for non blocking fields).
     const warnings = []
+
     // Email update separated, so if email fail core fields still saved.
-    if (String(email).trim()) {
+    if (email) {
       const emailResponse = await patchUser({
         fetch,
         userId,
-        payload: { email: String(email).trim() }
+        payload: { email }
       })
-      if (!emailResponse.ok) warnings.push('Email could not be updated')
+
+      if (!emailResponse.ok) {
+        warnings.push('Email could not be updated')
+      }
     }
 
-    await updateResponse.json().catch(() => ({}))
-
     const warn = warnings[0]
+
     if (warn) {
       throw redirect(303, `/profile?saved=1&warning=${encodeURIComponent(warn)}`)
     }
+
     throw redirect(303, '/profile?saved=1')
   },
 
   uploadAvatar: async ({ request, fetch, locals }) => {
     const sessionUser = locals.user
-    if (!sessionUser) return { ok: false, message: 'Unauthorized' }
-    if (!DIRECTUS_TOKEN) return { ok: false, message: 'Server config missing' }
+
+    if (!sessionUser) {
+      return { ok: false, message: 'Unauthorized' }
+    }
+
+    if (!DIRECTUS_TOKEN) {
+      return { ok: false, message: 'Server config missing' }
+    }
 
     const form = await request.formData().catch(() => null)
     const avatar = form?.get('avatar')
-    if (!(avatar instanceof File)) return { ok: false, message: 'No avatar file uploaded' }
+
+    if (!(avatar instanceof File)) {
+      return { ok: false, message: 'No avatar file uploaded' }
+    }
 
     const uploadBody = new FormData()
     uploadBody.append('file', avatar)
+
     const uploadResponse = await fetch(`${DIRECTUS_URL}/files`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${DIRECTUS_TOKEN}` },
+      headers: {
+        Authorization: `Bearer ${DIRECTUS_TOKEN}`
+      },
       body: uploadBody
     })
 
     if (!uploadResponse.ok) {
       const details = await uploadResponse.text().catch(() => '')
-      return { ok: false, message: 'Avatar upload failed', details }
+
+      return {
+        ok: false,
+        message: 'Avatar upload failed',
+        details
+      }
     }
 
     const uploadData = await uploadResponse.json().catch(() => null)
     const photoId = uploadData?.data?.id
-    if (!photoId) return { ok: false, message: 'Upload succeeded but file id missing' }
 
-    return { ok: true, photo: photoId }
+    if (!photoId) {
+      return {
+        ok: false,
+        message: 'Upload succeeded but file id missing'
+      }
+    }
+
+    return {
+      ok: true,
+      photo: photoId
+    }
   }
 }


### PR DESCRIPTION
…. #364

- Add createGroup() function to groups.js (POST to footguard_workgroups)
- Add createGroup form action to +page.server.js with server-side validation
- Update +page.svelte to append new group reactively via extraGroups without page reload

## What does this change?

Resolves issue #364

Admins need to be able to create new workgroups from the Groups page. 
This PR adds the backend logic needed to support that feature.

Before this change, there was no way to create a new group via the app — 
only directly in Directus. Now a `createGroup` form action exists that 
accepts a group name (required), condition label, status, and image ID 
(optional), validates the input server-side, and saves the new group to 
`footguard_workgroups` via the Directus REST API.

The `+page.svelte` is updated with an `extraGroups` reactive variable so 
the newly created group appears in the list immediately after creation, 
without a full page reload.


## How Has This Been Tested?
Backend action tested manually via a temporary test form submitting to 
`?/createGroup` with valid and invalid inputs:
- Empty group name → returns 400 with field error
- Valid group name → group created in Directus and returned in response
- Duplicate submit → deduplicated in frontend via extraGroups filter


### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

1. Check out this branch and run the dev server
2. Open `/groups` in the browser
3. Open DevTools → Network tab
4. Submit a temporary test form with `action="?/createGroup"` and 
   `name="groupName"` value set to a new group name
5. Confirm the new group appears in the Directus `footguard_workgroups` 
   collection and in the groups list on the page without a reload
6. Submit again with an empty group name and confirm a 400 error is returned
