### PR TITLE
fix: update AddGroupButton to use correct BEM class names #382

### DIFF
--- a/src/lib/components/groups/AddGroupButton.svelte
+++ b/src/lib/components/groups/AddGroupButton.svelte
@@ -22,9 +22,13 @@
   );
 </script>
 
-<svelte:element this={rootTag} class="add-group-btn" {...rootAttrs}>
-  <span class="add-group-btn__text">{label}</span>
-  <span class="add-group-btn__icon">
+<svelte:element
+  this={rootTag}
+  class="button button-primary button-large button-spread"
+  {...rootAttrs}
+>
+  <span class="button__text">{label}</span>
+  <span class="button__icon">
     <PulsIconNoBackground width={22} height={22} />
   </span>
 </svelte:element>


### PR DESCRIPTION
## What does this change?

Resolves issue #382 

had a bug in the styling of the create group button.
I replace .add-group-btn, .add-group-btn__text and .add-group-btn__icon with the global .button .button-primary .button-large .button-spread classes and correct BEM element names .button__text and .button__icon.



## Images

<img width="706" height="607" alt="Screenshot 2026-05-20 at 14 38 03" src="https://github.com/user-attachments/assets/4081a1b8-f899-4d7b-a016-ce133b947cb0" />


## How to review

1.  Pull this pullrequest.
2. Go to the group page.
3. Check the styling of the create group button( It should be same like the photo).