### PR TITLE
381 user story create creategroupmodal component file

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -215,10 +215,10 @@ Right-side drawer to create a new group. Uses native `<dialog>` with semantic ma
 
 **Bestanden:** `src/lib/components/groups/CreateGroupModal.svelte` · `src/lib/css/styleguide.css` (classes onder `.create-group-modal`)
 
-| Prop     | Type       | Default | Uitleg                                              |
-| -------- | ---------- | ------- | --------------------------------------------------- |
-| `open`   | boolean    | false   | Panel open (SSR: `?create-new-group` via `+page.server.js`) |
-| `onClose`| `() => void` | —     | Optional callback after dialog closes (JS)          |
+| Prop      | Type         | Default | Uitleg                                                      |
+| --------- | ------------ | ------- | ----------------------------------------------------------- |
+| `open`    | boolean      | false   | Panel open (SSR: `?create-new-group` via `+page.server.js`) |
+| `onClose` | `() => void` | —       | Optional callback after dialog closes (JS)                  |
 
 **No-JS:** panel uses native `open` on SSR only; close is a GET form to `/groups`. With JS, `showModal()` / `close()` handle the drawer (no `open` attribute in the browser).
 
@@ -238,12 +238,12 @@ Primary control to open the create-group drawer. Built on the shared `.button` s
 
 **Bestanden:** `src/lib/components/groups/AddGroupButton.svelte` · `styleguide.css` (modifier `.button--add-group`)
 
-| Prop       | Type                      | Default              | Uitleg                                        |
-| ---------- | ------------------------- | -------------------- | --------------------------------------------- |
-| `label`    | string                    | `Create New Group`   | Visible label                                 |
-| `href`     | string                    | `/groups?create-new-group` | Link target without JS                  |
-| `onclick`  | `(event) => void`         | —                    | Optional; `preventDefault` when JS is enabled |
-| `disabled` | boolean                   | false                | Renders inactive `<span>`                     |
+| Prop       | Type              | Default                    | Uitleg                                        |
+| ---------- | ----------------- | -------------------------- | --------------------------------------------- |
+| `label`    | string            | `Create New Group`         | Visible label                                 |
+| `href`     | string            | `/groups?create-new-group` | Link target without JS                        |
+| `onclick`  | `(event) => void` | —                          | Optional; `preventDefault` when JS is enabled |
+| `disabled` | boolean           | false                      | Renders inactive `<span>`                     |
 
 Combine **`.button` + `.button-primary` + `.button-medium` + `.button-spread` + `.button--add-group`**. Label text uses **`.button__text`**.
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -63,6 +63,10 @@ Elke map bevat componenten die een vergelijkbare functie of stijl delen.
    3.2 QuestionCard  
    3.3 GradingValue
 
+4. Groups pagina  
+   4.1 CreateGroupModal  
+   4.2 AddGroupButton
+
 ---
 
 ## 1. Componenten in de Researchpagina
@@ -200,6 +204,52 @@ De kaart waarin de vragen worden weergegeven.
 Dit component toont de antwoorden (bijvoorbeeld “Yes” of “No”) in de tabel.
 
 <img width="176" height="34" alt="Image" src="https://github.com/user-attachments/assets/cea7cf16-bbab-4c82-8f55-a3e09daae06e" />
+
+---
+
+## 4. Groups pagina
+
+### 4.1 CreateGroupModal
+
+Right-side drawer to create a new group. Uses native `<dialog>` with semantic markup (`section`, `header`, `h2`).
+
+**Bestanden:** `src/lib/components/groups/CreateGroupModal.svelte` · `src/lib/css/styleguide.css` (classes onder `.create-group-modal`)
+
+| Prop     | Type       | Default | Uitleg                                              |
+| -------- | ---------- | ------- | --------------------------------------------------- |
+| `open`   | boolean    | false   | Panel open (SSR: `?create-new-group` via `+page.server.js`) |
+| `onClose`| `() => void` | —     | Optional callback after dialog closes (JS)          |
+
+**No-JS:** panel uses native `open` on SSR only; close is a GET form to `/groups`. With JS, `showModal()` / `close()` handle the drawer (no `open` attribute in the browser).
+
+**Escape:** closes via native `<dialog>` behaviour; no unsaved-changes guard yet.
+
+**BEM classes:** `.create-group-modal`, `.create-group-modal__panel`, `.create-group-modal__header`, `.create-group-modal__close`, `.create-group-modal__title`
+
+```svelte
+<CreateGroupModal open={createModalOpen} onClose={closeCreateModal} />
+```
+
+---
+
+### 4.2 AddGroupButton
+
+Primary control to open the create-group drawer. Built on the shared `.button` system from `styleguide.css`.
+
+**Bestanden:** `src/lib/components/groups/AddGroupButton.svelte` · `styleguide.css` (modifier `.button--add-group`)
+
+| Prop       | Type                      | Default              | Uitleg                                        |
+| ---------- | ------------------------- | -------------------- | --------------------------------------------- |
+| `label`    | string                    | `Create New Group`   | Visible label                                 |
+| `href`     | string                    | `/groups?create-new-group` | Link target without JS                  |
+| `onclick`  | `(event) => void`         | —                    | Optional; `preventDefault` when JS is enabled |
+| `disabled` | boolean                   | false                | Renders inactive `<span>`                     |
+
+Combine **`.button` + `.button-primary` + `.button-medium` + `.button-spread` + `.button--add-group`**. Label text uses **`.button__text`**.
+
+```svelte
+<AddGroupButton onclick={openCreateModal} />
+```
 
 ---
 

--- a/src/lib/assets/svg/CloseIcon.svelte
+++ b/src/lib/assets/svg/CloseIcon.svelte
@@ -1,0 +1,26 @@
+<script>
+  export let width = 19
+  export let height = 19
+</script>
+
+<svg
+  {width}
+  {height}
+  viewBox="0 0 19 19"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
+>
+  <path
+    d="M2 2.00391L16.0705 16.0744"
+    stroke="currentColor"
+    stroke-width="4"
+    stroke-linecap="round"
+  />
+  <path
+    d="M2 16.0703L16.0705 1.99984"
+    stroke="currentColor"
+    stroke-width="4"
+    stroke-linecap="round"
+  />
+</svg>

--- a/src/lib/components/groups/AddGroupButton.svelte
+++ b/src/lib/components/groups/AddGroupButton.svelte
@@ -26,25 +26,6 @@
     event.preventDefault()
     onclick(event)
   }
-
-  /** resolve() only accepts pathnames — query strings are appended after. */
-  function toAppHref(path) {
-    const queryIndex = path.indexOf('?')
-    let pathname = queryIndex === -1 ? path : path.slice(0, queryIndex)
-    const search = queryIndex === -1 ? '' : path.slice(queryIndex)
-
-    if (pathname.startsWith('.')) {
-      pathname = pathname.replace(/^\.\//, '/')
-    }
-
-    if (!pathname.startsWith('/')) {
-      pathname = `/${pathname}`
-    }
-
-    return `${resolve(pathname)}${search}`
-  }
-
-  const linkHref = $derived(toAppHref(href))
 </script>
 
 {#if inactive}
@@ -60,7 +41,7 @@
 {:else}
   <a
     class="button button-primary button-medium button-spread button--add-group"
-    href={linkHref}
+    href={resolve(href)}
     onclick={handleClick}
   >
     <span class="button__text">{label}</span>

--- a/src/lib/components/groups/AddGroupButton.svelte
+++ b/src/lib/components/groups/AddGroupButton.svelte
@@ -1,35 +1,71 @@
 <script>
-  import { resolve } from "$app/paths";
-  import PulsIconNoBackground from "$lib/assets/svg/puls-icon-no-background.svelte";
+  import { resolve } from '$app/paths'
+  import PulsIconNoBackground from '$lib/assets/svg/puls-icon-no-background.svelte'
 
   /**
-   * Create-new-group control for the groups page.
+   * Opens the create-group flow. Uses a real link for no-JS; optional onclick for SPA behaviour.
    *
-   * Props:
-   * - label — visible text (default: “Create New Group”).
-   * - href — app path (default: /groups/new); passed through resolve() when the control is a link.
-   * - disabled — with no href, shows an inactive control (not a fake link).
-   *
-   * Renders `<span aria-disabled>` when there is no real link, otherwise `<a href={resolve(href)}>`.
-   * Label + icon are written once using `<svelte:element>` (DRY).
+   * @type {{
+   *   label?: string,
+   *   disabled?: boolean,
+   *   href?: string,
+   *   onclick?: (event: MouseEvent) => void
+   * }}
    */
-  let { label = "Create New Group", disabled = false, href = "/groups/new" } = $props();
+  let {
+    label = 'Create New Group',
+    disabled = false,
+    href = '/groups?create-new-group',
+    onclick = null
+  } = $props()
 
-  let inactive = $derived(disabled || !href);
-  let rootTag = $derived(inactive ? "span" : "a");
-  let rootAttrs = $derived(
-    inactive ? { "aria-disabled": "true" } : { href: resolve(href) }
-  );
+  let inactive = $derived(disabled || !href)
+
+  function handleClick(event) {
+    if (!onclick) return
+    event.preventDefault()
+    onclick(event)
+  }
+
+  /** resolve() only accepts pathnames — query strings are appended after. */
+  function toAppHref(path) {
+    const queryIndex = path.indexOf('?')
+    let pathname = queryIndex === -1 ? path : path.slice(0, queryIndex)
+    const search = queryIndex === -1 ? '' : path.slice(queryIndex)
+
+    if (pathname.startsWith('.')) {
+      pathname = pathname.replace(/^\.\//, '/')
+    }
+
+    if (!pathname.startsWith('/')) {
+      pathname = `/${pathname}`
+    }
+
+    return `${resolve(pathname)}${search}`
+  }
+
+  const linkHref = $derived(toAppHref(href))
 </script>
 
-<svelte:element
-  this={rootTag}
-  class="button button-primary button-large button-spread"
-  {...rootAttrs}
->
-  <span class="button__text">{label}</span>
-  <span class="button__icon">
-    <PulsIconNoBackground width={22} height={22} />
+{#if inactive}
+  <span
+    class="button button-primary button-medium button-spread button--add-group"
+    aria-disabled="true"
+  >
+    <span class="button__text">{label}</span>
+    <span class="button__icon">
+      <PulsIconNoBackground width={22} height={22} />
+    </span>
   </span>
-</svelte:element>
-
+{:else}
+  <a
+    class="button button-primary button-medium button-spread button--add-group"
+    href={linkHref}
+    onclick={handleClick}
+  >
+    <span class="button__text">{label}</span>
+    <span class="button__icon">
+      <PulsIconNoBackground width={22} height={22} />
+    </span>
+  </a>
+{/if}

--- a/src/lib/components/groups/CreateGroupModal.svelte
+++ b/src/lib/components/groups/CreateGroupModal.svelte
@@ -78,6 +78,20 @@
         required
         autocomplete="off"
       />
+      <label for="create-group-modal-condition-label" class="create-group-modal__form-label">
+        Condition Label
+        <span class="create-group-modal__form-required" aria-hidden="true">*</span>
+        <span class="sr-only">(required)</span>
+      </label>
+      <input
+        id="create-group-modal-condition-label"
+        name="conditionLabel"
+        type="text"
+        class="create-group-modal__form-input"
+        placeholder="Give The Group A Label"
+        required
+        autocomplete="off"
+      />
       <button
         type="submit"
         class="button button-primary button-medium button-full-width create-group-modal__submit"

--- a/src/lib/components/groups/CreateGroupModal.svelte
+++ b/src/lib/components/groups/CreateGroupModal.svelte
@@ -62,5 +62,28 @@
       </form>
       <h2 id="create-group-modal-title" class="create-group-modal__title">Create New Group</h2>
     </header>
+
+    <form method="POST" action="?/createGroup" class="create-group-modal__form">
+      <label for="create-group-modal-group-name" class="create-group-modal__form-label">
+        Group Name
+        <span class="create-group-modal__form-required" aria-hidden="true">*</span>
+        <span class="sr-only">(required)</span>
+      </label>
+      <input
+        id="create-group-modal-group-name"
+        name="groupName"
+        type="text"
+        class="create-group-modal__form-input"
+        placeholder="Name the group"
+        required
+        autocomplete="off"
+      />
+      <button
+        type="submit"
+        class="button button-primary button-medium button-full-width create-group-modal__submit"
+      >
+        Create Group
+      </button>
+    </form>
   </section>
 </dialog>

--- a/src/lib/components/groups/CreateGroupModal.svelte
+++ b/src/lib/components/groups/CreateGroupModal.svelte
@@ -1,0 +1,66 @@
+<script>
+  /**
+   * CreateGroupModal component
+   * Right-side drawer to create a new group.
+   * Parent controls open/onClose from +page.svelte (?create-new-group or the create button).
+   */
+  import { browser } from '$app/environment'
+  import { resolve } from '$app/paths'
+  import CloseIcon from '$lib/assets/svg/CloseIcon.svelte'
+
+  /** @type {{ open?: boolean, onClose?: () => void }} */
+  let { open = false, onClose } = $props()
+
+  /** @type {HTMLDialogElement | undefined} */
+  let dialogEl = $state()
+
+  const groupsPath = resolve('/groups')
+
+  function handleCloseSubmit(event) {
+    // With JS: close via dialog → handleDialogClose. Without JS: form navigates to /groups
+    if (!browser) return
+    event.preventDefault()
+    dialogEl.close()
+  }
+
+  function handleDialogClose() {
+    // Single exit for Escape, backdrop, and close button (when open is still true)
+    if (open) onClose?.()
+  }
+
+  // Browser: open/close with showModal() — do not use the `open` attribute (conflicts with modal mode)
+  $effect(() => {
+    if (!dialogEl || !browser) return
+    if (open && !dialogEl.open) dialogEl.showModal()
+    else if (!open && dialogEl.open) dialogEl.close()
+  })
+</script>
+
+<!-- Native dialog: backdrop, focus trap, and Escape. SSR uses `open` when JS is off. -->
+<dialog
+  bind:this={dialogEl}
+  class="create-group-modal"
+  aria-labelledby="create-group-modal-title"
+  open={!browser && open ? true : undefined}
+  onclose={handleDialogClose}
+  onclick={(event) => {
+    if (event.target === dialogEl) dialogEl.close()
+  }}
+>
+  <section class="create-group-modal__panel" aria-label="Create new group">
+    <header class="create-group-modal__header">
+      <!-- Close: button for screen readers; GET /groups works without JS -->
+      <form
+        method="GET"
+        action={groupsPath}
+        class="create-group-modal__close-form"
+        onsubmit={handleCloseSubmit}
+      >
+        <button type="submit" class="create-group-modal__close" aria-label="Close">
+          <CloseIcon />
+        </button>
+      </form>
+      <h2 id="create-group-modal-title" class="create-group-modal__title">Create New Group</h2>
+    </header>
+  </section>
+</dialog>

--- a/src/lib/components/groups/GroupAboutBanner.svelte
+++ b/src/lib/components/groups/GroupAboutBanner.svelte
@@ -27,7 +27,6 @@
   p {
     margin: 0;
     order: 1;
-    font-size: 1rem;
     font-weight: 300;
     line-height: 1.6;
   }
@@ -55,8 +54,6 @@
 
   @container group-about-banner (min-width: 48rem) {
     p {
-      /* large-copy values from styleguide.css */
-      font-size: 1.5rem;
       line-height: 1.5;
     }
   }

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -108,6 +108,7 @@
   --blue-700: hsl(203, 90%, 22%);
   --blue-600: hsl(203, 85%, 32%);
   --blue-500: hsl(203, 80%, 42%);
+  --blue-500-ring: hsl(203 80% 42% / 20%);
   --blue-400: hsl(203, 75%, 52%);
   --blue-300: hsl(203, 65%, 65%);
   --blue-200: hsl(203, 60%, 78%);
@@ -151,6 +152,7 @@
   --theme-wound-healing: #6a77dd;
 
   /* Neutral / grey */
+  --grey-900: hsl(210, 14%, 9%);
   --grey-700: hsl(210, 12%, 15%);
   --grey-600: hsl(210, 10%, 25%);
   --grey-500: hsl(210, 8%, 40%);
@@ -508,6 +510,123 @@ button {
       transform: none;
     }
   }
+
+  &.button--add-group {
+    margin-inline-start: auto;
+    text-decoration: none;
+  }
+}
+
+/* CreateGroupModal */
+.create-group-modal {
+  margin: 0 0 0 auto;
+  padding: 0;
+  border: none;
+  width: min(100%, 28rem);
+  height: 100%;
+  max-height: 100dvh;
+  background: transparent;
+}
+
+.create-group-modal::backdrop {
+  background: rgb(0 0 0 / 0.35);
+}
+
+.create-group-modal[open] {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.create-group-modal__panel {
+  width: 100%;
+  height: 100%;
+  padding: var(--spacing-xl);
+  overflow-y: auto;
+  background: var(--background-color-primary);
+  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
+  box-shadow: -4px 0 16px rgb(0 0 0 / 0.1);
+}
+
+.create-group-modal__header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  margin: 0 0 var(--spacing-xl);
+}
+
+.create-group-modal__close-form {
+  margin: 0;
+  padding: 0;
+  border: none;
+  align-self: flex-start;
+}
+
+.create-group-modal__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--grey-900);
+  line-height: 0;
+  cursor: pointer;
+}
+
+.create-group-modal__close:hover {
+  color: var(--grey-700);
+}
+
+.create-group-modal__title {
+  margin: 0;
+  width: 100%;
+  font-size: clamp(1.5rem, 2.5vw, 1.875rem);
+  font-weight: 700;
+  line-height: var(--line-height-tight);
+  color: var(--grey-900);
+  text-align: left;
+}
+
+.create-group-modal__form {
+  display: grid;
+  gap: var(--spacing-md);
+  margin: 0;
+}
+
+.create-group-modal__submit {
+  margin-top: var(--spacing-sm);
+}
+
+.create-group-modal__form-label {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--grey-900);
+}
+
+.create-group-modal__form-required {
+  color: var(--red-500);
+}
+
+.create-group-modal__form-input {
+  width: 100%;
+  margin: 0;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--grey-300);
+  border-radius: var(--radius-md);
+  background: var(--background-color-primary);
+  color: var(--grey-900);
+}
+
+.create-group-modal__form-input::placeholder {
+  color: var(--grey-400);
+}
+
+.create-group-modal__form-input:focus {
+  outline: none;
+  border-color: var(--blue-500);
+  box-shadow: 0 0 0 2px var(--blue-500-ring);
 }
 
 input,

--- a/src/routes/groups/+page.server.js
+++ b/src/routes/groups/+page.server.js
@@ -12,8 +12,23 @@ import {
 } from '$lib/server/groups.js'
 import { error, fail } from '@sveltejs/kit'
 
+function normalizeRole(role) {
+  return String(role ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '_')
+}
+
+function isAdminUser(user) {
+  const role = normalizeRole(user?.role)
+  return role === 'admin' || role === 'super_admin'
+}
+
+/** Query param that opens the create-group drawer (see +page.svelte, AddGroupButton). */
+const CREATE_GROUP_QUERY = 'create-new-group'
+
 /** @type {import('./$types').PageServerLoad} */
-export async function load() {
+export async function load({ locals, url }) {
   try {
     const groups = await fetchGroups()
 
@@ -34,10 +49,15 @@ export async function load() {
       })
     )
 
-    // Pass groups (with their members) to +page.svelte via the data prop
+    const isAdmin = isAdminUser(locals.user)
+    const openCreateGroupFromUrl = url.searchParams.has(CREATE_GROUP_QUERY)
+
     return {
       groups: groupsWithData,
-      loadError: null
+      loadError: null,
+      isAdmin,
+      // Open create-group drawer when URL has ?create-new-group (admins only).
+      showCreateModal: isAdmin && openCreateGroupFromUrl
     }
   } catch {
     // Throw a proper SvelteKit error with status code

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import { goto } from '$app/navigation'
+  import { resolve } from '$app/paths'
   import GroupAboutBanner from '$lib/components/groups/GroupAboutBanner.svelte'
   import GroupCard from '$lib/components/groups/GroupCard.svelte'
   import GroupFilter from '$lib/components/groupFilter/GroupFilter.svelte'
@@ -19,7 +20,7 @@
   function openCreateModal(event) {
     event?.preventDefault?.()
     showCreateGroupModal = true
-    goto('/groups?create-new-group', {
+    goto(resolve('/groups?create-new-group'), {
       replaceState: true,
       keepFocus: true,
       noScroll: true
@@ -28,7 +29,7 @@
 
   function closeCreateModal() {
     showCreateGroupModal = false
-    goto('/groups', { replaceState: true, keepFocus: true, noScroll: true })
+    goto(resolve('/groups'), { replaceState: true, keepFocus: true, noScroll: true })
   }
 
   const groups = $derived(

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -1,78 +1,92 @@
 <script>
-  import GroupAboutBanner from "$lib/components/groups/GroupAboutBanner.svelte";
-  import GroupCard from "$lib/components/groups/GroupCard.svelte";
-  import GroupFilter from "$lib/components/groupFilter/GroupFilter.svelte";
-  import AddGroupButton from "$lib/components/groups/AddGroupButton.svelte";
+  import { goto } from '$app/navigation'
+  import GroupAboutBanner from '$lib/components/groups/GroupAboutBanner.svelte'
+  import GroupCard from '$lib/components/groups/GroupCard.svelte'
+  import GroupFilter from '$lib/components/groupFilter/GroupFilter.svelte'
+  import AddGroupButton from '$lib/components/groups/AddGroupButton.svelte'
+  import CreateGroupModal from '$lib/components/groups/CreateGroupModal.svelte'
 
-  // `data` is injected by SvelteKit from +page.server.js
-  // It contains the groups array fetched from Directus
-  export let data;
-  export let form;
- 
+  /** @type {import('./$types').PageData} */
+  let { data, form } = $props()
+
   // Holds groups created during this session (not yet in server data).
-  // Kept separate so server data changes don't wipe newly added groups.
-  let extraGroups = [];
- 
-  // Merge server groups + locally added groups, deduplicate by id.
-  // Deduplication prevents doubles if the server data refreshes and already
-  // includes a group that was added via the createGroup action.
-  $: groups = [...(data.groups ?? []), ...extraGroups].filter(
-    (g, i, arr) => arr.findIndex((x) => x.id === g.id) === i
-  );
- 
-  $: loadError = data.loadError ?? null;
- 
-  // Loading state is true until groups or an error value is available
-  $: isLoading = !data?.groups && !data?.loadError;
- 
-  // When createGroup succeeds, append the new group to extraGroups so it
-  // appears in the list immediately without a full page reload.
-  $: if (form?.action === 'createGroup' && form?.success && form?.group) {
-    const alreadyExists =
-      (data.groups ?? []).some((g) => g.id === form.group.id) ||
-      extraGroups.some((g) => g.id === form.group.id);
- 
-    if (!alreadyExists) {
-      extraGroups = [form.group, ...extraGroups];
-    }
+  let extraGroups = $state([])
+
+  let showCreateGroupModal = $state(false)
+
+  const createModalOpen = $derived(showCreateGroupModal || data.showCreateModal)
+
+  function openCreateModal(event) {
+    event?.preventDefault?.()
+    showCreateGroupModal = true
+    goto('/groups?create-new-group', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true
+    })
   }
 
+  function closeCreateModal() {
+    showCreateGroupModal = false
+    goto('/groups', { replaceState: true, keepFocus: true, noScroll: true })
+  }
+
+  const groups = $derived(
+    [...data.groups, ...extraGroups].filter(
+      (g, i, arr) => arr.findIndex((x) => x.id === g.id) === i
+    )
+  )
+
+  const isLoading = $derived(!data.groups && !data.loadError)
+
+  $effect(() => {
+    if (form?.action !== 'createGroup' || !form?.success || !form?.group) return
+
+    const alreadyExists =
+      data.groups.some((g) => g.id === form.group.id) ||
+      extraGroups.some((g) => g.id === form.group.id)
+
+    if (!alreadyExists) {
+      extraGroups = [form.group, ...extraGroups]
+    }
+  })
 </script>
 
 <section class="groups-page">
   <h1>Groups</h1>
 
   <article class="groups-intro">
-      <!-- TODO: Move banner content source to directus data fields and remove fallback text. --> 
-      <!-- TODO: Replace this placeholder banner with dynamic data from the group data. -->   
+    <!-- TODO: Move banner content source to directus data fields and remove fallback text. -->
+    <!-- TODO: Replace this placeholder banner with dynamic data from the group data. -->
     <GroupAboutBanner>
       Manage members, invite users by email, and quickly update group access.
     </GroupAboutBanner>
-    <div class="groups-controls">
+    <section class="groups-controls" aria-label="Group filters and actions">
       <GroupFilter />
-      <AddGroupButton href="/groups/new" />
-    </div>
-  {#if isLoading}
-  <!-- Loading state -->
-  <p>Loading groups...</p>
-
-{:else if loadError}
-  <!-- Error state -->
-  <p class="groups-status groups-status--error">Something went wrong while loading groups.</p>
-
-{:else if groups.length === 0}
-      <!-- Empty state -->
+      {#if data.isAdmin}
+        <AddGroupButton onclick={openCreateModal} />
+      {/if}
+    </section>
+    {#if isLoading}
+      <p>Loading groups...</p>
+    {:else if data.loadError}
+      <p class="groups-status groups-status--error">
+        Something went wrong while loading groups.
+      </p>
+    {:else if groups.length === 0}
       <p class="groups-status">No groups available at the moment. Check back later!</p>
-
-{:else}
-  <!-- Success state -->
-  <div class="groups-cards">
-    {#each groups as group (group.id)}
-      <GroupCard {group} {form} />
-    {/each}
-  </div>
-{/if}
+    {:else}
+      <div class="groups-cards">
+        {#each groups as group (group.id)}
+          <GroupCard {group} {form} />
+        {/each}
+      </div>
+    {/if}
   </article>
+
+  {#if data.isAdmin}
+    <CreateGroupModal open={createModalOpen} onClose={closeCreateModal} />
+  {/if}
 </section>
 
 <style>
@@ -109,6 +123,7 @@
       flex-wrap: wrap;
       align-items: center;
       gap: var(--spacing-sm);
+      width: 100%;
     }
 
     .groups-status {
@@ -118,7 +133,7 @@
     }
 
     .groups-status--error {
-      color: var(--color-danger, #dc2626);
+      color: var(--red-500);
     }
   }
 


### PR DESCRIPTION
## What does this change?

Resolves issue #381 , #374

Adds a CreateGroupModal so group admins and super admins can create a new group directly from the groups page without navigating away. 
The modal opens as a right-side drawer and posts to the ?/createGroup server action.

The modal is only visible to admins (data.isAdmin). 
The open state is synced to the URL (?create-new-group) so the modal survives a page refresh and works without JS.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images

**- Open model** 
<img width="1137" height="836" alt="Screenshot 2026-05-21 at 21 36 48" src="https://github.com/user-attachments/assets/80170389-c9c4-4b19-89de-e92add4c64c1" />

**- Creat new group** 

<img width="1137" height="786" alt="Screenshot 2026-05-21 at 21 37 00" src="https://github.com/user-attachments/assets/080b615d-4c8f-4770-a667-514c2616d3cc" />

## How to review

1. Pull the branch and open the groups page as an admin
2. Click Create New Group  the drawer should slide in from the right
3. Fill in group name and condition label and submit group should  appear in the list without a full page reload
4. Close via the X button, Escape key, or clicking the backdrop modal should close and URL should return to /groups
5. Log in as a non-admin and confirm the Create New Group button and modal are not visible
6. Tab through the open modal and confirm focus stays trapped inside
