### PR TITLE
feat: remove Admin and Settings navigation items from sidebar. #390

### DIFF
--- a/src/lib/components/layout/MobileNav.svelte
+++ b/src/lib/components/layout/MobileNav.svelte
@@ -1,12 +1,10 @@
 <script>
 	import {
-		AdminIcon,
 		DashboardIcon,
 		GradingIcon,
 		NotificationIcon,
 		ProfileIcon,
 		ResultsIcon,
-		SettingIcon,
 		IwgdfLogo,
 		LogoutIcon,
 	} from "$lib";
@@ -67,22 +65,10 @@
 				<span class="label">Results</span>
 			</a>
 		</li>
-		<li class="admin-item">
-			<a href={resolve("/admin")}>	
-				<span class="icon"><AdminIcon /></span>
-				<span class="label">Admin</span>
-			</a>
-		</li>
 		<li>
 			<a href={resolve("/notifications")}>
 				<span class="icon"><NotificationIcon /></span>
 				<span class="label">Notifications</span>
-			</a>
-		</li>
-		<li>
-			<a href={resolve("/settings")}>
-				<span class="icon"><SettingIcon /></span>
-				<span class="label">Settings</span>
 			</a>
 		</li>
 		 <li>

--- a/src/lib/components/layout/Navbar.svelte
+++ b/src/lib/components/layout/Navbar.svelte
@@ -1,6 +1,5 @@
 <script>
   import {
-    AdminIcon,
     CollapseMenuIcon,
     DashboardIcon,
     GradingIcon,
@@ -8,7 +7,6 @@
     NotificationIcon,
     ProfileIcon,
     ResultsIcon,
-    SettingIcon,
     IwgdfLogo,
     IwgdfLogoCollapsed
   } from "$lib";
@@ -74,22 +72,10 @@
           <span class="label">Results</span>
         </a>
       </li>
-      <li class="admin-item">
-        <a href={resolve("/admin")}>
-          <span class="icon"><AdminIcon /></span>
-          <span class="label">Admin</span>
-        </a>
-      </li>
       <li>
         <a href={resolve("/notifications")}>
           <span class="icon"><NotificationIcon /></span>
           <span class="label">Notifications</span>
-        </a>
-      </li>
-      <li>
-        <a href={resolve("/settings")}>
-          <span class="icon"><SettingIcon /></span>
-          <span class="label">Settings</span>
         </a>
       </li>
     {/if}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -3,13 +3,11 @@ export { default as Navbar } from './components/layout/Navbar.svelte'
 export { default as MobileNav } from './components/layout/MobileNav.svelte'
 
 // Navbar svelte icons
-export { default as AdminIcon } from './components/navbar-icons/admin-icon.svelte'
 export { default as CollapseMenuIcon } from './components/navbar-icons/collapse-menu-icon.svelte'
 export { default as DashboardIcon } from './components/navbar-icons/dashboard-icon.svelte'
 export { default as GradingIcon } from './components/navbar-icons/grading-icon.svelte'
 export { default as NotificationIcon } from './components/navbar-icons/notification-icon.svelte'
 export { default as ResultsIcon } from './components/navbar-icons/results-icon.svelte'
-export { default as SettingIcon } from './components/navbar-icons/setting-icon.svelte'
 export { default as ProfileIcon } from './components/navbar-icons/profile-icon.svelte'
 export { default as IwgdfLogo } from './components/navbar-icons/IWGDF-Logo.svelte'
 export { default as IwgdfLogoCollapsed } from './components/navbar-icons/IWGDGF-Logo-Collapsed.svelte'


### PR DESCRIPTION

## What does this change?

Resolves issue #390 

Users reported the sidebar contained navigation items (Admin and Settings) 
that were not relevant for most users, making the navigation cluttered and 
confusing. This PR removes both items from the sidebar to improve the 
navigation experience.

Changes made:
- Removed Admin and Settings `<li>` items from `Navbar.svelte` (desktop)
- Removed Admin and Settings `<li>` items from `MobileNav.svelte` (mobile)
- Removed `AdminIcon` and `SettingIcon` exports from `index.js`

## How Has This Been Tested?
### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

<img width="238" height="713" alt="Screenshot 2026-05-29 at 12 35 42" src="https://github.com/user-attachments/assets/f3d691fb-519f-4f6b-b069-da16b454fbf2" />


## How to review

1. Check out this branch and run `npm run dev`
2. Open the sidebar on desktop — Admin and Settings items should no longer be visible
3. Open the mobile menu — Admin and Settings items should no longer be visible
4. Verify all remaining navigation links (Dashboard, Profile, Grading, Results, 
   Notifications, Logout) still work correctly
5. Check browser console for any missing import errors
