### PR TITLE
374 user story adding photo/users input

### DIFF
--- a/src/lib/assets/svg/DropdownIcon.svelte
+++ b/src/lib/assets/svg/DropdownIcon.svelte
@@ -1,0 +1,18 @@
+<script>
+  export let width = 16
+  export let height = 16
+</script>
+
+<svg
+  {width}
+  {height}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <polyline points="18 15 12 9 6 15" />
+</svg>

--- a/src/lib/components/groupFilter/GroupFilter.svelte
+++ b/src/lib/components/groupFilter/GroupFilter.svelte
@@ -1,5 +1,5 @@
 <script>
-  import DetailsUpIcon from "$lib/assets/svg/DetailsUpIcon.svelte";
+  import DropdownIcon from "$lib/assets/svg/DropdownIcon.svelte";
 </script>
 
 <form class="select-wrap" method="GET" action="/groups">
@@ -12,7 +12,7 @@
         <option value="2027">Guidelines 2027</option>
       </select>
       <span class="chevron" aria-hidden="true">
-        <DetailsUpIcon />
+        <DropdownIcon />
       </span>
 </form>
 

--- a/src/lib/components/groups/AddGroupButton.svelte
+++ b/src/lib/components/groups/AddGroupButton.svelte
@@ -9,22 +9,22 @@
    *   label?: string,
    *   disabled?: boolean,
    *   href?: string,
-   *   onclick?: (event: MouseEvent) => void
+   *   onOpen?: ((event: MouseEvent) => void) | null
    * }}
    */
   let {
     label = 'Create New Group',
     disabled = false,
     href = '/groups?create-new-group',
-    onclick = null
+    onOpen = null
   } = $props()
 
   let inactive = $derived(disabled || !href)
 
   function handleClick(event) {
-    if (!onclick) return
+    if (!onOpen) return
     event.preventDefault()
-    onclick(event)
+    onOpen(event)
   }
 </script>
 

--- a/src/lib/components/groups/CreateGroupModal.svelte
+++ b/src/lib/components/groups/CreateGroupModal.svelte
@@ -253,7 +253,6 @@
             <button
               type="button"
               class="create-group-modal__member-toggle"
-              class:create-group-modal__member-toggle--open={membersOpen}
               aria-label={membersOpen ? 'Close members list' : 'Open members list'}
               aria-expanded={membersOpen}
               aria-controls="create-group-members-list"
@@ -411,10 +410,6 @@
     background: var(--background-color-primary);
     box-shadow: 0 0 16px rgb(0 0 0 / 0.1);
     pointer-events: all;
-  }
-
-  .create-group-modal__member-toggle--open :global(svg) {
-    transform: rotate(180deg);
   }
 
   /* Desktop: right-side drawer */

--- a/src/lib/components/groups/CreateGroupModal.svelte
+++ b/src/lib/components/groups/CreateGroupModal.svelte
@@ -368,19 +368,11 @@
 
         <div class="create-group-modal__actions">
           <button
-            type="button"
-            class="button button-outline button-medium"
-            disabled={isSubmitting}
-            onclick={requestClose}
-          >
-            Cancel
-          </button>
-          <button
             type="submit"
             class="button button-primary button-medium"
             disabled={isSubmitting}
           >
-            {isSubmitting ? 'Creating…' : 'Create Group'}
+            {isSubmitting ? 'Submitting…' : 'Submit'}
           </button>
         </div>
       </form>

--- a/src/lib/components/groups/CreateGroupModal.svelte
+++ b/src/lib/components/groups/CreateGroupModal.svelte
@@ -4,100 +4,430 @@
    * Right-side drawer to create a new group.
    * Parent controls open/onClose from +page.svelte (?create-new-group or the create button).
    */
+  import { enhance } from '$app/forms'
   import { browser } from '$app/environment'
-  import { resolve } from '$app/paths'
   import CloseIcon from '$lib/assets/svg/CloseIcon.svelte'
+  import DropdownIcon from '$lib/assets/svg/DropdownIcon.svelte'
+  import searchIcon from '$lib/assets/svg/search-icon.svg'
 
-  /** @type {{ open?: boolean, onClose?: () => void }} */
-  let { open = false, onClose } = $props()
+  /**
+   * @typedef {{ id: number, name: string, email?: string | null }} MemberOption
+   */
 
-  /** @type {HTMLDialogElement | undefined} */
-  let dialogEl = $state()
+  /** @type {{
+   *   open?: boolean,
+   *   onClose?: () => void,
+   *   form?: import('@sveltejs/kit').ActionData | null,
+   *   memberOptions?: MemberOption[]
+   * }} */
+  let { open = false, onClose, form = null, memberOptions = [] } = $props()
 
-  const groupsPath = resolve('/groups')
+  let membersFieldEl = $state(/** @type {HTMLElement | null} */ (null))
+  let fileInput = $state(/** @type {HTMLInputElement | null} */ (null))
 
-  function handleCloseSubmit(event) {
-    // With JS: close via dialog → handleDialogClose. Without JS: form navigates to /groups
-    if (!browser) return
-    event.preventDefault()
-    dialogEl.close()
-  }
+  let memberQuery = $state('')
+  /** @type {number[]} */
+  let selectedMemberIds = $state([])
+  let membersOpen = $state(false)
+  let isDragging = $state(false)
+  let thumbnailName = $state('')
+  let groupNameError = $state('')
+  let submitError = $state('')
+  let isSubmitting = $state(false)
 
-  function handleDialogClose() {
-    // Single exit for Escape, backdrop, and close button (when open is still true)
-    if (open) onClose?.()
-  }
+  const statusOptions = ['active', 'draft', 'inactive']
 
-  // Browser: open/close with showModal() — do not use the `open` attribute (conflicts with modal mode)
+  const filteredMembers = $derived(
+    memberOptions.filter((member) => {
+      const query = memberQuery.trim().toLowerCase()
+      if (!query) return true
+      const haystack = `${member.name ?? ''} ${member.email ?? ''}`.toLowerCase()
+      return haystack.includes(query)
+    })
+  )
+
+  const selectedMembers = $derived(
+    memberOptions.filter((member) => selectedMemberIds.includes(member.id))
+  )
+
+  // Reset when modal closes
   $effect(() => {
-    if (!dialogEl || !browser) return
-    if (open && !dialogEl.open) dialogEl.showModal()
-    else if (!open && dialogEl.open) dialogEl.close()
+    if (!open) {
+      memberQuery = ''
+      selectedMemberIds = []
+      membersOpen = false
+      isDragging = false
+      thumbnailName = ''
+      groupNameError = ''
+      submitError = ''
+      isSubmitting = false
+      if (fileInput) fileInput.value = ''
+    }
   })
+
+  // Sync form errors from server
+  $effect(() => {
+    if (!form || !open) return
+    if (form.action === 'createGroup' && form.error) {
+      if (form.field === 'groupName') {
+        groupNameError = form.error
+      } else {
+        submitError = form.error
+      }
+    }
+  })
+
+  // Lock body scroll when open
+  $effect(() => {
+    if (!browser) return
+    document.body.style.overflow = open ? 'hidden' : ''
+    return () => {
+      document.body.style.overflow = ''
+    }
+  })
+
+  function requestClose() {
+    if (isSubmitting) return
+    onClose?.()
+  }
+
+  function handleBackdropClick(event) {
+    if (event.target === event.currentTarget) requestClose()
+  }
+
+  function handleKeydown(event) {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      requestClose()
+    }
+  }
+
+  function handleMembersBlur(event) {
+    const next = /** @type {HTMLElement | null} */ (event.relatedTarget)
+    if (!membersFieldEl?.contains(next)) {
+      membersOpen = false
+    }
+  }
+
+  function toggleMember(memberId) {
+    if (selectedMemberIds.includes(memberId)) {
+      selectedMemberIds = selectedMemberIds.filter((id) => id !== memberId)
+    } else {
+      selectedMemberIds = [...selectedMemberIds, memberId]
+    }
+  }
+
+  function handleFileSelect(file) {
+    if (!file?.type?.startsWith('image/')) {
+      submitError = 'Please choose an image file for the thumbnail.'
+      return
+    }
+    submitError = ''
+    thumbnailName = file.name
+  }
+
+  function handleDrop(event) {
+    event.preventDefault()
+    isDragging = false
+    const file = event.dataTransfer?.files?.[0]
+    if (!file || !fileInput) return
+    const transfer = new DataTransfer()
+    transfer.items.add(file)
+    fileInput.files = transfer.files
+    handleFileSelect(file)
+  }
+
+  function handleSubmit() {
+    groupNameError = ''
+    submitError = ''
+    isSubmitting = true
+
+    return async ({ result, update }) => {
+      isSubmitting = false
+
+      if (result.type === 'success' && result.data?.action === 'createGroup') {
+        requestClose()
+      }
+
+      if (result.type === 'failure' && result.data?.action === 'createGroup') {
+        if (result.data?.field === 'groupName') {
+          groupNameError = result.data?.error || 'Group name is required.'
+        } else {
+          submitError = result.data?.error || 'Failed to create group. Please try again.'
+        }
+      }
+
+      await update({ reset: false })
+    }
+  }
 </script>
 
-<!-- Native dialog: backdrop, focus trap, and Escape. SSR uses `open` when JS is off. -->
-<dialog
-  bind:this={dialogEl}
-  class="create-group-modal"
-  aria-labelledby="create-group-modal-title"
-  open={!browser && open ? true : undefined}
-  onclose={handleDialogClose}
-  onclick={(event) => {
-    if (event.target === dialogEl) dialogEl.close()
-  }}
->
-  <section class="create-group-modal__panel" aria-label="Create new group">
-    <header class="create-group-modal__header">
-      <!-- Close: button for screen readers; GET /groups works without JS -->
-      <form
-        method="GET"
-        action={groupsPath}
-        class="create-group-modal__close-form"
-        onsubmit={handleCloseSubmit}
-      >
-        <button type="submit" class="create-group-modal__close" aria-label="Close">
-          <CloseIcon />
-        </button>
-      </form>
-      <h2 id="create-group-modal-title" class="create-group-modal__title">Create New Group</h2>
-    </header>
+<svelte:window onkeydown={open ? handleKeydown : undefined} />
 
-    <form method="POST" action="?/createGroup" class="create-group-modal__form">
-      <label for="create-group-modal-group-name" class="create-group-modal__form-label">
-        Group Name
-        <span class="create-group-modal__form-required" aria-hidden="true">*</span>
-        <span class="sr-only">(required)</span>
-      </label>
-      <input
-        id="create-group-modal-group-name"
-        name="groupName"
-        type="text"
-        class="create-group-modal__form-input"
-        placeholder="Name the group"
-        required
-        autocomplete="off"
-      />
-      <label for="create-group-modal-condition-label" class="create-group-modal__form-label">
-        Condition Label
-        <span class="create-group-modal__form-required" aria-hidden="true">*</span>
-        <span class="sr-only">(required)</span>
-      </label>
-      <input
-        id="create-group-modal-condition-label"
-        name="conditionLabel"
-        type="text"
-        class="create-group-modal__form-input"
-        placeholder="Give The Group A Label"
-        required
-        autocomplete="off"
-      />
-      <button
-        type="submit"
-        class="button button-primary button-medium button-full-width create-group-modal__submit"
+{#if open}
+  <div class="modal-backdrop" role="presentation" onclick={handleBackdropClick}>
+    <section
+      class="create-group-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-group-modal-title"
+      onclick={(e) => e.stopPropagation()}
+    >
+      <header class="create-group-modal__header">
+        <h2 id="create-group-modal-title" class="create-group-modal__title">Create New Group</h2>
+        <button
+          type="button"
+          class="button button-medium create-group-modal__close"
+          aria-label="Close"
+          onclick={requestClose}
+        >
+          <CloseIcon width={16} height={16} />
+        </button>
+      </header>
+
+      <form
+        method="POST"
+        action="?/createGroup"
+        enctype="multipart/form-data"
+        class="create-group-modal__form"
+        use:enhance={handleSubmit}
       >
-        Create Group
-      </button>
-    </form>
-  </section>
-</dialog>
+        <label for="create-group-modal-group-name" class="create-group-modal__form-label">
+          Group Name
+          <span class="create-group-modal__form-required" aria-hidden="true">*</span>
+        </label>
+        <input
+          id="create-group-modal-group-name"
+          name="groupName"
+          type="text"
+          class="create-group-modal__form-input"
+          placeholder="Name the group"
+          required
+          disabled={isSubmitting}
+          aria-invalid={groupNameError ? 'true' : undefined}
+          aria-describedby={groupNameError ? 'create-group-name-error' : undefined}
+        />
+        {#if groupNameError}
+          <p id="create-group-name-error" class="create-group-modal__form-error" role="alert">
+            {groupNameError}
+          </p>
+        {/if}
+
+        <label for="create-group-modal-condition-label" class="create-group-modal__form-label">
+          Condition Label
+        </label>
+        <input
+          id="create-group-modal-condition-label"
+          name="conditionLabel"
+          type="text"
+          class="create-group-modal__form-input"
+          placeholder="Give the group a label"
+          disabled={isSubmitting}
+        />
+
+        <div class="create-group-modal__members" bind:this={membersFieldEl}>
+          <span class="create-group-modal__form-label" id="create-group-members-label">
+            Add Members
+          </span>
+          <div class="create-group-modal__member-search">
+            <img
+              class="create-group-modal__member-search-icon"
+              src={searchIcon}
+              alt=""
+              aria-hidden="true"
+            />
+            <input
+              id="create-group-members"
+              type="search"
+              class="create-group-modal__form-input create-group-modal__member-search-input"
+              placeholder="Search members"
+              bind:value={memberQuery}
+              disabled={isSubmitting}
+              role="combobox"
+              aria-autocomplete="list"
+              aria-controls="create-group-members-list"
+              aria-expanded={membersOpen}
+              onfocus={() => (membersOpen = true)}
+              onblur={handleMembersBlur}
+            />
+            <button
+              type="button"
+              class="create-group-modal__member-toggle"
+              class:create-group-modal__member-toggle--open={membersOpen}
+              aria-label={membersOpen ? 'Close members list' : 'Open members list'}
+              aria-expanded={membersOpen}
+              aria-controls="create-group-members-list"
+              disabled={isSubmitting || memberOptions.length === 0}
+              onclick={() => (membersOpen = !membersOpen)}
+            >
+              <DropdownIcon />
+            </button>
+          </div>
+
+          {#if membersOpen && filteredMembers.length > 0}
+            <ul
+              id="create-group-members-list"
+              class="create-group-modal__member-list"
+              role="listbox"
+              aria-labelledby="create-group-members-label"
+            >
+              {#each filteredMembers as member (member.id)}
+                <li role="option" aria-selected={selectedMemberIds.includes(member.id)}>
+                  <button
+                    type="button"
+                    class="create-group-modal__member-option"
+                    class:create-group-modal__member-option--selected={selectedMemberIds.includes(member.id)}
+                    onmousedown={(e) => e.preventDefault()}
+                    onclick={() => toggleMember(member.id)}
+                  >
+                    <span>{member.name}</span>
+                    {#if member.email}
+                      <span class="create-group-modal__member-option-email">{member.email}</span>
+                    {/if}
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+
+          {#if selectedMembers.length > 0}
+            <ul class="create-group-modal__member-chips" aria-label="Selected members">
+              {#each selectedMembers as member (member.id)}
+                <li class="create-group-modal__member-chip">
+                  {member.name}
+                  <button
+                    type="button"
+                    class="create-group-modal__member-chip-remove"
+                    aria-label={`Remove ${member.name}`}
+                    onclick={() => toggleMember(member.id)}
+                  >
+                    &times;
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+
+        {#each selectedMemberIds as memberId (memberId)}
+          <input type="hidden" name="memberIds" value={memberId} />
+        {/each}
+
+        <label for="create-group-modal-status" class="create-group-modal__form-label">
+          Status
+        </label>
+        <div class="create-group-modal__select-wrap">
+          <select
+            id="create-group-modal-status"
+            name="status"
+            class="create-group-modal__form-input create-group-modal__select"
+            disabled={isSubmitting}
+          >
+            <option value="">Status</option>
+            {#each statusOptions as option (option)}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+          <span class="create-group-modal__select-chevron" aria-hidden="true">
+            <DropdownIcon />
+          </span>
+        </div>
+
+        <span class="create-group-modal__form-label" id="create-group-thumbnail-label">
+          Upload a thumbnail
+        </span>
+        <label
+          class="create-group-modal__upload"
+          class:create-group-modal__upload--dragging={isDragging}
+          for="create-group-thumbnail"
+          ondragover={(e) => { e.preventDefault(); isDragging = true }}
+          ondragleave={() => (isDragging = false)}
+          ondrop={handleDrop}
+        >
+          <p>
+            Drag and drop your file here, or
+            <span class="create-group-modal__upload-browse">browse</span>
+          </p>
+          {#if thumbnailName}
+            <p class="create-group-modal__upload-filename">{thumbnailName}</p>
+          {/if}
+        </label>
+        <input
+          bind:this={fileInput}
+          id="create-group-thumbnail"
+          class="sr-only"
+          type="file"
+          name="thumbnail"
+          accept="image/*"
+          disabled={isSubmitting}
+          onchange={(e) => handleFileSelect(e.currentTarget.files?.[0])}
+        />
+
+        {#if submitError}
+          <p class="create-group-modal__form-error" role="alert">{submitError}</p>
+        {/if}
+
+        <div class="create-group-modal__actions">
+          <button
+            type="button"
+            class="button button-outline button-medium"
+            disabled={isSubmitting}
+            onclick={requestClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            class="button button-primary button-medium"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Creating…' : 'Create Group'}
+          </button>
+        </div>
+      </form>
+    </section>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: stretch;
+    justify-content: stretch;
+    pointer-events: all;
+  }
+
+  .create-group-modal {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    max-height: 100dvh;
+    overflow-y: auto;
+    padding: var(--spacing-lg);
+    background: var(--background-color-primary);
+    box-shadow: 0 0 16px rgb(0 0 0 / 0.1);
+    pointer-events: all;
+  }
+
+  .create-group-modal__member-toggle--open :global(svg) {
+    transform: rotate(180deg);
+  }
+
+  /* Desktop: right-side drawer */
+  @container groups-page (min-width: 48rem) {
+    .modal-backdrop {
+      justify-content: flex-end;
+    }
+
+    .create-group-modal {
+      width: min(100%, 28rem);
+      padding: var(--spacing-xl);
+      border-radius: var(--radius-lg) 0 0 var(--radius-lg);
+      box-shadow: -4px 0 16px rgb(0 0 0 / 0.1);
+    }
+  }
+</style>

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -518,70 +518,35 @@ button {
 }
 
 /* CreateGroupModal */
-.create-group-modal {
-  margin: 0 0 0 auto;
-  padding: 0;
-  border: none;
-  width: min(100%, 28rem);
-  height: 100%;
-  max-height: 100dvh;
-  background: transparent;
-}
-
-.create-group-modal::backdrop {
-  background: rgb(0 0 0 / 0.35);
-}
-
-.create-group-modal[open] {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.create-group-modal__panel {
-  width: 100%;
-  height: 100%;
-  padding: var(--spacing-xl);
-  overflow-y: auto;
-  background: var(--background-color-primary);
-  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
-  box-shadow: -4px 0 16px rgb(0 0 0 / 0.1);
-}
-
 .create-group-modal__header {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
   gap: var(--spacing-sm);
   margin: 0 0 var(--spacing-xl);
 }
 
-.create-group-modal__close-form {
-  margin: 0;
-  padding: 0;
-  border: none;
-  align-self: flex-start;
-}
-
 .create-group-modal__close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  margin: 0;
-  padding: 0;
+  flex-shrink: 0;
+  min-width: unset;
+  width: auto;
+  padding-inline: 1.25rem;
+  line-height: 0;
   border: none;
   background: transparent;
-  color: var(--grey-900);
-  line-height: 0;
-  cursor: pointer;
+  color: var(--grey-700);
+  transition: color 150ms ease;
 }
 
-.create-group-modal__close:hover {
-  color: var(--grey-700);
+.create-group-modal__close:hover,
+.create-group-modal__close:focus-visible {
+  background: transparent;
+  color: var(--blue-500);
 }
 
 .create-group-modal__title {
   margin: 0;
-  width: 100%;
   font-size: clamp(1.5rem, 2.5vw, 1.875rem);
   font-weight: 700;
   line-height: var(--line-height-tight);
@@ -593,10 +558,6 @@ button {
   display: grid;
   gap: var(--spacing-md);
   margin: 0;
-}
-
-.create-group-modal__submit {
-  margin-top: var(--spacing-sm);
 }
 
 .create-group-modal__form-label {
@@ -627,6 +588,197 @@ button {
   outline: none;
   border-color: var(--blue-500);
   box-shadow: 0 0 0 2px var(--blue-500-ring);
+}
+
+.create-group-modal__select-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.create-group-modal__select {
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  padding-right: calc(var(--spacing-md) + 1.5rem);
+}
+
+.create-group-modal__select::-ms-expand {
+  display: none;
+}
+
+.create-group-modal__select-chevron {
+  position: absolute;
+  right: var(--spacing-md);
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  color: var(--grey-500);
+  pointer-events: none;
+}
+
+.create-group-modal__form-error {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--red-500);
+}
+
+.create-group-modal__members {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.create-group-modal__member-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.create-group-modal__member-search-icon {
+  position: absolute;
+  left: var(--spacing-md);
+  width: 1rem;
+  height: 1rem;
+  pointer-events: none;
+}
+
+.create-group-modal__member-search-input {
+  padding-left: calc(var(--spacing-md) + 1.25rem);
+  padding-right: calc(var(--spacing-md) + 1.75rem);
+}
+
+.create-group-modal__member-toggle {
+  position: absolute;
+  right: var(--spacing-xs);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--grey-500);
+  cursor: pointer;
+}
+
+.create-group-modal__member-toggle[aria-expanded='true'] {
+  transform: rotate(180deg);
+}
+
+.create-group-modal__member-list {
+  margin: 0;
+  padding: var(--spacing-xxs);
+  list-style: none;
+  max-height: 8rem;
+  overflow: auto;
+  border: 1px solid var(--grey-300);
+  border-radius: var(--radius-md);
+  background: var(--background-color-primary);
+}
+
+.create-group-modal__member-option {
+  width: 100%;
+  display: grid;
+  gap: 0.125rem;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  text-align: left;
+  color: var(--grey-700);
+  cursor: pointer;
+}
+
+.create-group-modal__member-option:hover,
+.create-group-modal__member-option:focus-visible {
+  background: var(--grey-50);
+}
+
+.create-group-modal__member-option--selected {
+  background: var(--blue-50);
+  color: var(--blue-700);
+}
+
+.create-group-modal__member-option-email {
+  font-size: 0.75rem;
+  color: var(--grey-500);
+}
+
+.create-group-modal__member-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.create-group-modal__member-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xxs);
+  padding: var(--spacing-xxs) var(--spacing-sm);
+  border-radius: var(--radius-full);
+  background: var(--blue-100);
+  color: var(--blue-700);
+  font-size: 0.875rem;
+}
+
+.create-group-modal__member-chip-remove {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+}
+
+.create-group-modal__upload {
+  display: grid;
+  justify-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-lg) var(--spacing-md);
+  border: 1px dashed var(--grey-300);
+  border-radius: var(--radius-md);
+  background: var(--grey-50);
+  text-align: center;
+  color: var(--grey-600);
+  cursor: pointer;
+}
+
+.create-group-modal__upload--dragging {
+  border-color: var(--blue-500);
+  background: var(--blue-50);
+}
+
+.create-group-modal__upload p {
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.create-group-modal__upload-browse {
+  color: var(--blue-500);
+  font-weight: 600;
+}
+
+.create-group-modal__upload-filename {
+  color: var(--grey-700);
+  font-weight: 500;
+}
+
+.create-group-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+}
+
+.create-group-modal__actions .button {
+  min-width: 8.5rem;
 }
 
 input,

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -459,7 +459,7 @@ export async function fetchUserOptions() {
     id: user.id,
     name: user.name || user.email || 'Unknown',
     email: user.email ?? null,
-    role: Array.isArray(user.role) ? user.role[0] : user.role ?? null
+    role: Array.isArray(user.role) ? user.role[0] : (user.role ?? null)
   }))
 }
 
@@ -471,9 +471,7 @@ export async function fetchUserOptions() {
  * @returns {Promise<object[]>}
  */
 export async function findUsersByIds(userIds) {
-  const ids = (userIds ?? [])
-    .map((id) => Number(id))
-    .filter((id) => Number.isFinite(id) && id > 0)
+  const ids = (userIds ?? []).map((id) => Number(id)).filter((id) => Number.isFinite(id) && id > 0)
 
   if (ids.length === 0) return []
 

--- a/src/lib/server/groups.js
+++ b/src/lib/server/groups.js
@@ -428,3 +428,137 @@ export async function createGroup({
   const json = await response.json()
   return json.data
 }
+
+/**
+ * Fetches users for the create-group member picker.
+ *
+ * @returns {Promise<Array<{ id: number, name: string, email: string | null, role: string | null }>>}
+ */
+export async function fetchUserOptions() {
+  const url = `${DIRECTUS_URL}/items/footguard_users?fields=id,name,email,role&limit=-1&sort=name`
+
+  let response
+  try {
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${DIRECTUS_TOKEN}`,
+        'Content-Type': 'application/json'
+      }
+    })
+  } catch (networkError) {
+    throw new Error(`Network error while fetching users: ${networkError.message}`)
+  }
+
+  if (!response.ok) {
+    throw new Error(`Directus API error while fetching users: ${response.status}`)
+  }
+
+  const json = await response.json()
+
+  return (json.data ?? []).map((user) => ({
+    id: user.id,
+    name: user.name || user.email || 'Unknown',
+    email: user.email ?? null,
+    role: Array.isArray(user.role) ? user.role[0] : user.role ?? null
+  }))
+}
+
+/**
+ * Bulk-fetches users from footguard_users by their IDs in a single request.
+ * Avoids the N+1 pattern of calling findUserById once per selected member.
+ *
+ * @param {Array<number | string>} userIds
+ * @returns {Promise<object[]>}
+ */
+export async function findUsersByIds(userIds) {
+  const ids = (userIds ?? [])
+    .map((id) => Number(id))
+    .filter((id) => Number.isFinite(id) && id > 0)
+
+  if (ids.length === 0) return []
+
+  const url = `${DIRECTUS_URL}/items/footguard_users?filter[id][_in]=${ids.join(',')}&fields=id,name,email,role&limit=-1`
+
+  let response
+  try {
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${DIRECTUS_TOKEN}`,
+        'Content-Type': 'application/json'
+      }
+    })
+  } catch (networkError) {
+    throw new Error(`Network error while looking up users: ${networkError.message}`)
+  }
+
+  if (!response.ok) {
+    throw new Error(`Directus API error while looking up users: ${response.status}`)
+  }
+
+  const json = await response.json()
+  return json.data ?? []
+}
+
+/**
+ * @param {number | string} userId
+ * @returns {Promise<object | null>}
+ */
+export async function findUserById(userId) {
+  const url = `${DIRECTUS_URL}/items/footguard_users?filter[id][_eq]=${Number(userId)}&fields=id,name,email,role&limit=1`
+
+  let response
+  try {
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${DIRECTUS_TOKEN}`,
+        'Content-Type': 'application/json'
+      }
+    })
+  } catch (networkError) {
+    throw new Error(`Network error while looking up user: ${networkError.message}`)
+  }
+
+  if (!response.ok) {
+    throw new Error(`Directus API error while looking up user: ${response.status}`)
+  }
+
+  const json = await response.json()
+  return json.data?.[0] ?? null
+}
+
+/**
+ * Uploads an image file to Directus and returns the file id.
+ *
+ * @param {File} file
+ * @returns {Promise<string>}
+ */
+export async function uploadImageToDirectus(file) {
+  const body = new FormData()
+  body.append('file', file)
+
+  let response
+  try {
+    response = await fetch(`${DIRECTUS_URL}/files`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DIRECTUS_TOKEN}`
+      },
+      body
+    })
+  } catch (networkError) {
+    throw new Error(`Network error while uploading image: ${networkError.message}`)
+  }
+
+  if (!response.ok) {
+    const details = await response.text().catch(() => '')
+    throw new Error(`Directus file upload failed (${response.status}): ${details}`)
+  }
+
+  const json = await response.json()
+  const fileId = json?.data?.id
+  if (!fileId) {
+    throw new Error('Directus file upload did not return a file id.')
+  }
+
+  return String(fileId)
+}

--- a/src/routes/groups/+page.server.js
+++ b/src/routes/groups/+page.server.js
@@ -8,8 +8,12 @@ import {
   addUserToGroup,
   removeMemberFromGroup,
   getGroupArticles,
-  createGroup
+  createGroup,
+  fetchUserOptions,
+  findUsersByIds,
+  uploadImageToDirectus
 } from '$lib/server/groups.js'
+import { DIRECTUS_URL } from '$env/static/private'
 import { error, fail } from '@sveltejs/kit'
 
 function normalizeRole(role) {
@@ -26,6 +30,20 @@ function isAdminUser(user) {
 
 /** Query param that opens the create-group drawer (see +page.svelte, AddGroupButton). */
 const CREATE_GROUP_QUERY = 'create-new-group'
+
+const MEMBER_ROLE_MAP = {
+  'super admin': 'Super Admin',
+  admin: 'Admin',
+  assessor: 'Assessor',
+  guest: 'Viewer'
+}
+
+function mapUserToMemberRole(rawRole) {
+  const key = String(rawRole ?? '')
+    .trim()
+    .toLowerCase()
+  return MEMBER_ROLE_MAP[key] ?? 'Viewer'
+}
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ locals, url }) {
@@ -51,11 +69,13 @@ export async function load({ locals, url }) {
 
     const isAdmin = isAdminUser(locals.user)
     const openCreateGroupFromUrl = url.searchParams.has(CREATE_GROUP_QUERY)
+    const memberOptions = isAdmin ? await fetchUserOptions() : []
 
     return {
       groups: groupsWithData,
       loadError: null,
       isAdmin,
+      memberOptions,
       // Open create-group drawer when URL has ?create-new-group (admins only).
       showCreateModal: isAdmin && openCreateGroupFromUrl
     }
@@ -178,22 +198,54 @@ export const actions = {
    * @type {import('./$types').Actions}
    */
   createGroup: async ({ request, locals }) => {
+    if (!isAdminUser(locals.user)) {
+      return fail(403, {
+        error: 'Only admins can create groups.',
+        action: 'createGroup'
+      })
+    }
+
     const data = await request.formData()
     const currentUserId = locals.user?.id ?? null
 
     const groupName = data.get('groupName')?.toString().trim()
     const conditionLabel = data.get('conditionLabel')?.toString().trim() || null
     const status = data.get('status')?.toString().trim() || null
-    // imageId comes later when the frontend modal with file upload is built
-    const imageId = data.get('imageId')?.toString().trim() || null
+    const memberIds = data
+      .getAll('memberIds')
+      .map((id) => Number(id))
+      .filter((id) => Number.isFinite(id) && id > 0)
 
-    // --- Validation: group name is the only required field ---
+    const thumbnail = data.get('thumbnail')
+
+    // Validate required fields before any upload, so a failed validation
+    // never leaves an orphaned file in Directus.
     if (!groupName) {
       return fail(400, {
         error: 'Group name is required.',
         field: 'groupName',
         action: 'createGroup'
       })
+    }
+
+    let imageId = null
+
+    if (thumbnail instanceof File && thumbnail.size > 0) {
+      if (!thumbnail.type.startsWith('image/')) {
+        return fail(400, {
+          error: 'Please choose an image file for the thumbnail.',
+          action: 'createGroup'
+        })
+      }
+
+      try {
+        imageId = await uploadImageToDirectus(thumbnail)
+      } catch (err) {
+        return fail(500, {
+          error: err.message || 'Failed to upload thumbnail.',
+          action: 'createGroup'
+        })
+      }
     }
 
     try {
@@ -205,8 +257,35 @@ export const actions = {
         imageId
       })
 
-      // Return the new group so the frontend can append it to the list
-      // without a full page reload.
+      const addedMembers = []
+
+      // The group is already created at this point, so member-adding failures
+      // must not fail the whole request — log and continue instead.
+      try {
+        // Single bulk lookup for all selected members (avoids N+1 per-user fetches).
+        const users = await findUsersByIds(memberIds)
+
+        for (const user of users) {
+          try {
+            const rawRole = Array.isArray(user.role) ? user.role[0] : user.role
+            const role = mapUserToMemberRole(rawRole)
+            await addUserToGroup(newGroup.id, user.id, currentUserId, role)
+
+            addedMembers.push({
+              id: user.id,
+              name: user.name || user.email || 'Unknown',
+              role,
+              email: user.email ?? null,
+              avatarUrl: null
+            })
+          } catch (memberErr) {
+            console.error('[createGroup] add member failed:', memberErr)
+          }
+        }
+      } catch (lookupErr) {
+        console.error('[createGroup] member lookup failed:', lookupErr)
+      }
+
       return {
         success: true,
         action: 'createGroup',
@@ -215,10 +294,10 @@ export const actions = {
           name: newGroup.group_name,
           status: newGroup.status ?? null,
           conditionlabel: newGroup.condition_label ?? 'General',
-          members: [],
-          memberCount: 0,
+          members: addedMembers,
+          memberCount: addedMembers.length,
           articles: [],
-          image: null // image upload handled later
+          image: imageId ? `${DIRECTUS_URL}/assets/${imageId}` : null
         }
       }
     } catch (err) {

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -15,7 +15,9 @@
 
   let showCreateGroupModal = $state(false)
 
-  const createModalOpen = $derived(showCreateGroupModal || data.showCreateModal)
+  const createModalOpen = $derived(
+    data.isAdmin && (showCreateGroupModal || data.showCreateModal)
+  )
 
   function openCreateModal(event) {
     event?.preventDefault?.()
@@ -29,7 +31,11 @@
 
   function closeCreateModal() {
     showCreateGroupModal = false
-    goto(resolve('/groups'), { replaceState: true, keepFocus: true, noScroll: true })
+    goto(resolve('/groups'), {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true
+    })
   }
 
   const groups = $derived(
@@ -50,6 +56,9 @@
     if (!alreadyExists) {
       extraGroups = [form.group, ...extraGroups]
     }
+
+    showCreateGroupModal = false
+    goto(resolve('/groups'), { replaceState: true, keepFocus: true, noScroll: true })
   })
 </script>
 
@@ -65,7 +74,7 @@
     <section class="groups-controls" aria-label="Group filters and actions">
       <GroupFilter />
       {#if data.isAdmin}
-        <AddGroupButton onclick={openCreateModal} />
+        <AddGroupButton onOpen={openCreateModal} />
       {/if}
     </section>
     {#if isLoading}
@@ -86,7 +95,12 @@
   </article>
 
   {#if data.isAdmin}
-    <CreateGroupModal open={createModalOpen} onClose={closeCreateModal} />
+    <CreateGroupModal
+      open={createModalOpen}
+      onClose={closeCreateModal}
+      {form}
+      memberOptions={data.memberOptions}
+    />
   {/if}
 </section>
 


### PR DESCRIPTION
## What does this change?

Resolves issue #391 #374

This is a sub-issue for the create new group feature. Individual pieces were reviewed on sub-branches.
Admins can now create a new group directly from the groups page via a right-side popup modal. 
The modal includes member search, status select, and thumbnail upload. 
The form posts to a server action that handles validation, thumbnail upload to Directus, and member adding.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images

<img width="451" height="826" alt="Screenshot 2026-05-29 at 15 09 12" src="https://github.com/user-attachments/assets/331d2cca-88d7-464f-88f3-066546210dfd" />

<img width="1582" height="1035" alt="Screenshot 2026-05-29 at 15 09 26" src="https://github.com/user-attachments/assets/3669ef40-e4f8-4bcd-b2d8-7f8e1a4f5cab" />

## How to review

1. Pull the branch and open the groups page as an admin
2. Click Create New Group — full screen on mobile, right drawer on desktop
3. Search for a member by name or email and select
4. Select a status from the dropdown
5. Drag an image onto the upload area — filename should appear
6. Submit with no group name — inline error should appear under the field
7. Submit a valid form — modal should close, URL should return to /groups, 
   and new group should appear in the list with correct members and thumbnail
10. Press Escape or click the backdrop — popup should close
11. Log in as a non-admin — Create New Group button and modal should 
    not be visible




