### PR TITLE
fix: prevent firefox overflow on grading pages

### DIFF
--- a/src/lib/components/cards/PdfCard.svelte
+++ b/src/lib/components/cards/PdfCard.svelte
@@ -12,22 +12,25 @@
 </article>
 
 <style>
-    .pdf-container {
-        background: var(--background-color-primary);
-        border-radius: 1rem;
-        height: 75vh;
-        padding: 1rem;
+  .pdf-container {
+    background: var(--background-color-primary);
+    border-radius: 1rem;
+    /* Fix: use min-height instead of fixed height so Firefox does not
+       push the element outside the parent container bounds. */
+    height: min(75vh, 800px);
+    padding: 1rem;
+    box-shadow:
+      0 0.25rem 0.75rem hsla(213, 12%, 15%, 0.12),
+      0 0.125rem 0.25rem hsla(213, 12%, 15%, 0.08);
+    border: 1px solid hsla(213, 12%, 15%, 0.06);
+    transition: transform 0.3s ease;
+    /* Fix: clip any content that overflows this card in Firefox */
+    overflow: hidden;
 
-        box-shadow:
-            0 0.25rem 0.75rem hsla(213, 12%, 15%, 0.12),
-            0 0.125rem 0.25rem hsla(213, 12%, 15%, 0.08);
-        border: 1px solid hsla(213, 12%, 15%, 0.06);
-        transition: transform 0.3s ease;
-
-        .pdf-file,
-        .pdf-file embed {
-            width: 100%;
-            height: 100%;
-        }
+    .pdf-file,
+    .pdf-file embed {
+      width: 100%;
+      height: 100%;
     }
+  }
 </style>

--- a/src/lib/components/cards/PdfCard.svelte
+++ b/src/lib/components/cards/PdfCard.svelte
@@ -15,8 +15,6 @@
   .pdf-container {
     background: var(--background-color-primary);
     border-radius: 1rem;
-    /* Fix: use min-height instead of fixed height so Firefox does not
-       push the element outside the parent container bounds. */
     height: min(75vh, 800px);
     padding: 1rem;
     box-shadow:
@@ -24,7 +22,6 @@
       0 0.125rem 0.25rem hsla(213, 12%, 15%, 0.08);
     border: 1px solid hsla(213, 12%, 15%, 0.06);
     transition: transform 0.3s ease;
-    /* Fix: clip any content that overflows this card in Firefox */
     overflow: hidden;
 
     .pdf-file,

--- a/src/lib/components/form/QuestionsForm.svelte
+++ b/src/lib/components/form/QuestionsForm.svelte
@@ -30,8 +30,6 @@
 
 <style>
   .questions-container {
-    /* Fix: use min-height with a cap so Firefox cannot grow this element
-       beyond the visible viewport and cause whitespace below the page. */
     height: min(75vh, 800px);
     display: flex;
     flex-direction: column;
@@ -44,7 +42,6 @@
       0 0.125rem 0.25rem hsla(213, 12%, 15%, 0.08);
     border: 1px solid hsla(213, 12%, 15%, 0.06);
     transition: transform 0.3s ease;
-    /* Fix: prevent Firefox from letting children escape this container */
     overflow: hidden;
   }
 
@@ -67,8 +64,6 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    /* Fix: remove overflow: scroll from the form itself — scroll only
-       happens in .questions-scroll-container to avoid double scrollbars */
     overflow: hidden;
     flex: 1;
     min-height: 0;
@@ -79,8 +74,6 @@
       gap: 1rem;
       display: flex;
       flex-direction: column;
-      /* Fix: min-height: 0 is required in Firefox for flex children
-         with overflow-y: auto to actually scroll instead of expanding */
       min-height: 0;
     }
   }

--- a/src/lib/components/form/QuestionsForm.svelte
+++ b/src/lib/components/form/QuestionsForm.svelte
@@ -29,77 +29,87 @@
 </article>
 
 <style>
-    .questions-container {
-        height: 75vh;
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-        background: var(--background-color-primary);
-        padding: 1rem;
-        border-radius: 1rem;
+  .questions-container {
+    /* Fix: use min-height with a cap so Firefox cannot grow this element
+       beyond the visible viewport and cause whitespace below the page. */
+    height: min(75vh, 800px);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    background: var(--background-color-primary);
+    padding: 1rem;
+    border-radius: 1rem;
+    box-shadow:
+      0 0.25rem 0.75rem hsla(213, 12%, 15%, 0.12),
+      0 0.125rem 0.25rem hsla(213, 12%, 15%, 0.08);
+    border: 1px solid hsla(213, 12%, 15%, 0.06);
+    transition: transform 0.3s ease;
+    /* Fix: prevent Firefox from letting children escape this container */
+    overflow: hidden;
+  }
 
-        box-shadow:
-            0 0.25rem 0.75rem hsla(213, 12%, 15%, 0.12),
-            0 0.125rem 0.25rem hsla(213, 12%, 15%, 0.08);
-        border: 1px solid hsla(213, 12%, 15%, 0.06);
-        transition: transform 0.3s ease;
+  h2 span,
+  .answered-questions span {
+    color: var(--grey-500);
+  }
+
+  .anwsered-questions-count-container {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    span {
+      font-weight: 700;
+    }
+  }
+
+  .questions-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    /* Fix: remove overflow: scroll from the form itself — scroll only
+       happens in .questions-scroll-container to avoid double scrollbars */
+    overflow: hidden;
+    flex: 1;
+    min-height: 0;
+
+    .questions-scroll-container {
+      flex: 1;
+      overflow-y: auto;
+      gap: 1rem;
+      display: flex;
+      flex-direction: column;
+      /* Fix: min-height: 0 is required in Firefox for flex children
+         with overflow-y: auto to actually scroll instead of expanding */
+      min-height: 0;
+    }
+  }
+
+  .buttons-container {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    padding: 0.1rem;
+    flex-shrink: 0;
+
+    .form-submit-button,
+    .form-save-button {
+      color: var(--font-color-card);
+      padding: 0.5rem;
+      border-radius: 1rem;
+      width: fit-content;
+      white-space: nowrap;
+      font-size: clamp(10px, 1.5vw, 16px);
+      transition: 0.2s ease-in-out;
+      cursor: pointer;
     }
 
-    h2 span,
-    .answered-questions span {
-        color: var(--grey-500);
+    .form-save-button {
+      background-color: var(--blue-600);
     }
 
-    .anwsered-questions-count-container {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-
-        span {
-            font-weight: 700;
-        }
+    .form-submit-button {
+      background-color: var(--green-600);
     }
-
-    .questions-form {
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-        overflow: scroll;
-
-        .questions-scroll-container {
-            flex: 1;
-            overflow-y: auto;
-            gap: 1rem;
-            display: flex;
-            flex-direction: column;
-        }
-    }
-
-    .buttons-container {
-        display: flex;
-        justify-content: flex-end;
-        gap: 1rem;
-        padding: 0.1rem;
-        flex-shrink: 0;
-
-        .form-submit-button,
-        .form-save-button {
-            color: var(--font-color-card);
-            padding: 0.5rem;
-            border-radius: 1rem;
-            width: fit-content;
-            white-space: nowrap;
-            font-size: clamp(10px, 1.5vw, 16px);
-            transition: 0.2s ease-in-out;
-            cursor: pointer;
-        }
-
-        .form-save-button {
-            background-color: var(--blue-600);
-        }
-
-        .form-submit-button {
-            background-color: var(--green-600);
-        }
-    }
+  }
 </style>

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -847,10 +847,6 @@ select {
   }
 }
 
-/* Fix: Firefox makes the body scrollable when child elements use
-   height: 75vh inside a fixed-sidebar layout. overflow: hidden on
-   body stops the page from scrolling; the page content scrolls
-   inside .page-content instead via the layout. */
 body {
   overflow: hidden;
 }

--- a/src/lib/css/styleguide.css
+++ b/src/lib/css/styleguide.css
@@ -846,3 +846,11 @@ select {
     scroll-behavior: auto !important;
   }
 }
+
+/* Fix: Firefox makes the body scrollable when child elements use
+   height: 75vh inside a fixed-sidebar layout. overflow: hidden on
+   body stops the page from scrolling; the page content scrolls
+   inside .page-content instead via the layout. */
+body {
+  overflow: hidden;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -55,7 +55,6 @@
 </div>
 
 <style>
-  /* Skip link - alleen zichtbaar bij keyboard focus */
   .skip-link {
     position: absolute;
     top: -100%;
@@ -84,25 +83,30 @@
 
   .app-layout {
     min-height: 100vh;
-    display: flex;
-    flex-direction: column;
   }
 
-  /* Main page content */
-  .page-content {
-    padding: 0;
-    @media (min-width: 769px) {
-      margin-left: 240px;
-      margin-top: 0;
+.page-content {
+  padding: 0;
+  overflow-y: auto;
+  height: 100vh;
 
-      &.collapsed {
-        margin-left: 80px;
-      }
-    }
+  @media (min-width: 769px) {
+    margin-left: 240px;
+    /* Fix: padding-top not needed since navbar is fixed and doesn't
+       push content down on desktop */
+    margin-top: 0;
 
-    @media (max-width: 768px) {
-      margin-top: 80px;
-      margin-left: 0;
+    &.collapsed {
+      margin-left: 80px;
     }
   }
+
+  @media (max-width: 768px) {
+    /* Fix: mobile navbar is 80px tall and fixed, so offset by that amount.
+       height must subtract the navbar to avoid overflow below viewport. */
+    margin-top: 80px;
+    margin-left: 0;
+    height: calc(100vh - 80px);
+  }
+}
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -92,8 +92,6 @@
 
   @media (min-width: 769px) {
     margin-left: 240px;
-    /* Fix: padding-top not needed since navbar is fixed and doesn't
-       push content down on desktop */
     margin-top: 0;
 
     &.collapsed {
@@ -102,8 +100,6 @@
   }
 
   @media (max-width: 768px) {
-    /* Fix: mobile navbar is 80px tall and fixed, so offset by that amount.
-       height must subtract the navbar to avoid overflow below viewport. */
     margin-top: 80px;
     margin-left: 0;
     height: calc(100vh - 80px);

--- a/src/routes/research/[article_id]/+page.svelte
+++ b/src/routes/research/[article_id]/+page.svelte
@@ -20,27 +20,27 @@
 </section>
 
 <style>
-	.main-container-checklist {
-		max-width: 100rem;
-  		margin: 0 auto;
-		width: 100%;
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-		padding: 1rem 1rem 1rem 1rem;
+  .main-container-checklist {
+    max-width: 100rem;
+    margin: 0 auto;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
 
-		@media (min-width: 720px) {
-			padding: 1rem 2rem 1rem 2rem;
-		}
-	}
+    @media (min-width: 720px) {
+      padding: 1rem 2rem;
+    }
+  }
 
-	.pdf-questions-container {
-		display: grid;
-		grid-template-columns: 1fr;
-		gap: 1rem;
+  .pdf-questions-container {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
 
-		@media (min-width: 1100px) {
-			grid-template-columns: 1fr 1fr;
-		}
-	}
+    @media (min-width: 1100px) {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
 </style>


### PR DESCRIPTION
## What does this change?

Resolves issue #219 

This fixes a Firefox-only overflow issue on the compare grading and grading result pages.

The page content previously used `height: 100vh` together with fixed navigation, which caused Firefox to render extra vertical whitespace below the page. The layout now correctly accounts for the fixed mobile navbar height and avoids unnecessary desktop offset spacing.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

### RAPPE Principles

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Progressive Enhancement test]() 
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

Tested on:
- Firefox desktop
- Firefox responsive/mobile viewport
- Chrome desktop to confirm no regression

## Images

<img width="1440" height="852" alt="Screenshot 2026-06-04 at 15 40 38" src="https://github.com/user-attachments/assets/d9e3aa2e-9c9e-4ccd-95f8-887f3285ebcf" />



## How to review

1. Open the grading page in Firefox.
2. Check that the page does not continue into extra white space at the bottom.
3. Open the compare grading page in Firefox.
4. Check that there is no vertical overflow.
5. Resize the browser below `768px`.
6. Confirm the mobile navbar is still visible and the page content fits below it.
7. Compare with Chrome to confirm the layout still behaves the same there.
